### PR TITLE
Fix crash on launch due to nullable entryId

### DIFF
--- a/shared/src/commonMain/kotlin/dev/igorcferreira/musicstreamsync/model/EntryData.kt
+++ b/shared/src/commonMain/kotlin/dev/igorcferreira/musicstreamsync/model/EntryData.kt
@@ -11,8 +11,8 @@ interface EntryData {
 val EntryData.entryId: String
     get() =
         when (this) {
-            is PlaylistEntry -> entryId
-            is MusicEntry -> entryId
+            is PlaylistEntry -> entryId ?: ""
+            is MusicEntry -> entryId ?: ""
             else -> this.id
         }
 

--- a/shared/src/commonMain/kotlin/dev/igorcferreira/musicstreamsync/model/MusicEntry.kt
+++ b/shared/src/commonMain/kotlin/dev/igorcferreira/musicstreamsync/model/MusicEntry.kt
@@ -2,7 +2,7 @@ package dev.igorcferreira.musicstreamsync.model
 
 data class MusicEntry(
     override val id: String,
-    val entryId: String,
+    val entryId: String?,
     override val title: String,
     val artist: String,
     override val artworkUrl: String,

--- a/shared/src/commonMain/kotlin/dev/igorcferreira/musicstreamsync/model/PlaylistEntry.kt
+++ b/shared/src/commonMain/kotlin/dev/igorcferreira/musicstreamsync/model/PlaylistEntry.kt
@@ -2,7 +2,7 @@ package dev.igorcferreira.musicstreamsync.model
 
 data class PlaylistEntry(
     override val id: String,
-    val entryId: String,
+    val entryId: String?,
     val name: String,
     val canEdit: Boolean,
     val hasCatalog: Boolean,


### PR DESCRIPTION
## Summary
- Apple's API now returns `null` for `entryId` in `MusicEntry` and `PlaylistEntry`, causing a crash on launch when deserializing into non-null fields
- Made `entryId` nullable (`String?`) in both model classes
- Updated the `EntryData.entryId` extension property to fall back to an empty string when null

## Test plan
- [x] Launch the app on iOS and Android and verify no crash occurs
- [x] Verify playback history and playlists load correctly when `entryId` is null
- [x] Verify existing entries with non-null `entryId` continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)