### PR TITLE
feat: Android feature parity, UI/UX improvements, and composable previews

### DIFF
--- a/composeApp/src/main/java/dev/igorcferreira/musicstreamsync/application/App.kt
+++ b/composeApp/src/main/java/dev/igorcferreira/musicstreamsync/application/App.kt
@@ -1,5 +1,6 @@
 package dev.igorcferreira.musicstreamsync.application
 
+import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.MaterialTheme
@@ -11,16 +12,41 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import dev.igorcferreira.musicstreamsync.R
+import dev.igorcferreira.musicstreamsync.application.theme.AppTheme
 import dev.igorcferreira.musicstreamsync.history.History
 import dev.igorcferreira.musicstreamsync.lastfm.LastFMToolbar
 import dev.igorcferreira.musicstreamsync.playlist.Playlist
+import dev.igorcferreira.musicstreamsync.scrobble.Scrobble
 
 @Composable
 fun App(modifier: Modifier = Modifier) {
     var tabIndex by remember { mutableIntStateOf(0) }
-    val tabs = listOf(R.string.history, R.string.playlists)
+    App(
+        modifier = modifier,
+        tabIndex = tabIndex,
+        onTabChange = { tabIndex = it },
+        toolbar = { LastFMToolbar() },
+    ) {
+        when (tabIndex) {
+            0 -> History()
+            1 -> Playlist()
+            2 -> Scrobble()
+        }
+    }
+}
+
+@Composable
+fun App(
+    modifier: Modifier = Modifier,
+    tabIndex: Int = 0,
+    onTabChange: (Int) -> Unit = {},
+    toolbar: @Composable () -> Unit = {},
+    content: @Composable () -> Unit = {},
+) {
+    val tabs = listOf(R.string.history, R.string.playlists, R.string.scrobble)
 
     Column(
         modifier =
@@ -44,13 +70,14 @@ fun App(modifier: Modifier = Modifier) {
                     when (tabIndex) {
                         0 -> stringResource(R.string.recently_played)
                         1 -> stringResource(R.string.playlists)
+                        2 -> stringResource(R.string.manual_scrobble)
                         else -> ""
                     },
                 color = MaterialTheme.colorScheme.primary,
                 style = MaterialTheme.typography.titleLarge,
                 fontWeight = FontWeight.Bold,
             )
-            LastFMToolbar()
+            toolbar()
         }
 
         PrimaryTabRow(selectedTabIndex = tabIndex) {
@@ -58,14 +85,83 @@ fun App(modifier: Modifier = Modifier) {
                 Tab(
                     text = { Text(stringResource(id = tab)) },
                     selected = tabIndex == index,
-                    onClick = { tabIndex = index },
+                    onClick = { onTabChange(index) },
                 )
             }
         }
 
-        when (tabIndex) {
-            0 -> History()
-            1 -> Playlist()
-        }
+        content()
+    }
+}
+
+@Preview(name = "History Tab — Light", showBackground = true)
+@Composable
+fun AppHistoryPreview() {
+    AppTheme {
+        App(
+            tabIndex = 0,
+            toolbar = {
+                LastFMToolbar(
+                    authenticated = false,
+                    authenticating = false,
+                    authenticate = { _, _ -> },
+                    logout = {},
+                )
+            },
+        )
+    }
+}
+
+@Preview(name = "Playlists Tab — Light", showBackground = true)
+@Composable
+fun AppPlaylistsPreview() {
+    AppTheme {
+        App(
+            tabIndex = 1,
+            toolbar = {
+                LastFMToolbar(
+                    authenticated = true,
+                    authenticating = false,
+                    authenticate = { _, _ -> },
+                    logout = {},
+                )
+            },
+        )
+    }
+}
+
+@Preview(name = "Scrobble Tab — Light", showBackground = true)
+@Composable
+fun AppScrobblePreview() {
+    AppTheme {
+        App(
+            tabIndex = 2,
+            toolbar = {
+                LastFMToolbar(
+                    authenticated = true,
+                    authenticating = false,
+                    authenticate = { _, _ -> },
+                    logout = {},
+                )
+            },
+        )
+    }
+}
+
+@Preview(name = "History Tab — Dark", uiMode = Configuration.UI_MODE_NIGHT_YES, showBackground = true)
+@Composable
+fun AppHistoryDarkPreview() {
+    AppTheme {
+        App(
+            tabIndex = 0,
+            toolbar = {
+                LastFMToolbar(
+                    authenticated = false,
+                    authenticating = false,
+                    authenticate = { _, _ -> },
+                    logout = {},
+                )
+            },
+        )
     }
 }

--- a/composeApp/src/main/java/dev/igorcferreira/musicstreamsync/di/ViewModelFactory.kt
+++ b/composeApp/src/main/java/dev/igorcferreira/musicstreamsync/di/ViewModelFactory.kt
@@ -10,11 +10,13 @@ import dev.igorcferreira.musicstreamsync.domain.Scrobbler
 import dev.igorcferreira.musicstreamsync.domain.player.MediaPlayerNativePlayer
 import dev.igorcferreira.musicstreamsync.domain.use_cases.LastFMUseCase
 import dev.igorcferreira.musicstreamsync.domain.use_cases.PlayerUseCase
+import dev.igorcferreira.musicstreamsync.domain.use_cases.RecentlyPlayedUseCase
 import dev.igorcferreira.musicstreamsync.history.RecentlyPlayedViewModel
 import dev.igorcferreira.musicstreamsync.lastfm.LastFMViewModel
 import dev.igorcferreira.musicstreamsync.model.Configuration
 import dev.igorcferreira.musicstreamsync.player.PlayerViewModel
 import dev.igorcferreira.musicstreamsync.playlist.PlaylistViewModel
+import dev.igorcferreira.musicstreamsync.scrobble.ScrobbleViewModel
 
 class ViewModelFactory {
     companion object {
@@ -92,6 +94,21 @@ class ViewModelFactory {
                     modelClass: Class<T>,
                     extras: CreationExtras,
                 ): T = RecentlyPlayedViewModel(configuration) as T
+            }
+
+        val Scrobble: ViewModelProvider.Factory =
+            object : ViewModelProvider.Factory {
+                @Suppress("UNCHECKED_CAST")
+                override fun <T : ViewModel> create(
+                    modelClass: Class<T>,
+                    extras: CreationExtras,
+                ): T {
+                    val application = checkNotNull(extras[APPLICATION_KEY])
+                    return ScrobbleViewModel(
+                        lastFMUseCase = buildLastFMUseCase(application),
+                        recentlyPlayedUseCase = RecentlyPlayedUseCase(configuration),
+                    ) as T
+                }
             }
     }
 }

--- a/composeApp/src/main/java/dev/igorcferreira/musicstreamsync/history/History.kt
+++ b/composeApp/src/main/java/dev/igorcferreira/musicstreamsync/history/History.kt
@@ -1,12 +1,17 @@
 package dev.igorcferreira.musicstreamsync.history
 
+import android.content.res.Configuration
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.viewmodel.compose.viewModel
+import dev.igorcferreira.musicstreamsync.application.theme.AppTheme
 import dev.igorcferreira.musicstreamsync.di.ViewModelFactory
 import dev.igorcferreira.musicstreamsync.list.Entry
 import dev.igorcferreira.musicstreamsync.list.EntryList
+import dev.igorcferreira.musicstreamsync.model.MusicEntry
 import dev.igorcferreira.musicstreamsync.player.Player
 
 @Composable
@@ -18,5 +23,75 @@ fun History(viewModel: RecentlyPlayedViewModel = viewModel(factory = ViewModelFa
         viewModel.updateHistory()
     }
 
-    EntryList(history.value, loading.value, { Entry(it) }, { Player() })
+    EntryList(
+        items = history.value,
+        loading = loading.value,
+        entry = { Entry(it) },
+        player = { Player() },
+        onRefresh = { viewModel.updateHistory() },
+    )
+}
+
+@Preview(name = "Loading — Light", showBackground = true)
+@Composable
+fun HistoryLoadingPreview() {
+    AppTheme {
+        EntryList(
+            items = listOf(),
+            loading = true,
+            entry = { Entry(Modifier, it) {} },
+            player = { Player(Modifier, null, false, {}, {}) },
+        )
+    }
+}
+
+@Preview(name = "Content — Light", showBackground = true)
+@Composable
+fun HistoryContentPreview() {
+    AppTheme {
+        EntryList(
+            items =
+                listOf(
+                    MusicEntry(
+                        id = "1184710148",
+                        title = "Stardust",
+                        artist = "Delain",
+                        artworkUrl = "",
+                        album = "The Human Contradiction",
+                    ),
+                    MusicEntry(
+                        id = "1184710149",
+                        title = "Here Come the Vultures",
+                        artist = "Delain",
+                        artworkUrl = "",
+                        album = "The Human Contradiction",
+                    ),
+                ),
+            loading = false,
+            entry = { Entry(Modifier, it) {} },
+            player = { Player(Modifier, null, false, {}, {}) },
+        )
+    }
+}
+
+@Preview(name = "Content — Dark", uiMode = Configuration.UI_MODE_NIGHT_YES, showBackground = true)
+@Composable
+fun HistoryContentDarkPreview() {
+    AppTheme {
+        EntryList(
+            items =
+                listOf(
+                    MusicEntry(
+                        id = "1184710148",
+                        title = "Stardust",
+                        artist = "Delain",
+                        artworkUrl = "",
+                        album = "The Human Contradiction",
+                    ),
+                ),
+            loading = false,
+            entry = { Entry(Modifier, it) {} },
+            player = { Player(Modifier, null, false, {}, {}) },
+        )
+    }
 }

--- a/composeApp/src/main/java/dev/igorcferreira/musicstreamsync/lastfm/LastFMToolbar.kt
+++ b/composeApp/src/main/java/dev/igorcferreira/musicstreamsync/lastfm/LastFMToolbar.kt
@@ -87,11 +87,24 @@ fun LastFMToolbar(
 }
 
 @Composable
-@Preview
+@Preview(name = "Unauthenticated")
 fun LastFMToolbarPreview() {
     AppTheme {
         LastFMToolbar(
             authenticated = false,
+            authenticating = false,
+            authenticate = { _, _ -> },
+            logout = { },
+        )
+    }
+}
+
+@Composable
+@Preview(name = "Authenticated")
+fun LastFMToolbarAuthenticatedPreview() {
+    AppTheme {
+        LastFMToolbar(
+            authenticated = true,
             authenticating = false,
             authenticate = { _, _ -> },
             logout = { },

--- a/composeApp/src/main/java/dev/igorcferreira/musicstreamsync/lastfm/LastFMViewModel.kt
+++ b/composeApp/src/main/java/dev/igorcferreira/musicstreamsync/lastfm/LastFMViewModel.kt
@@ -3,6 +3,7 @@ package dev.igorcferreira.musicstreamsync.lastfm
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dev.igorcferreira.musicstreamsync.domain.use_cases.LastFMUseCase
+import dev.igorcferreira.musicstreamsync.model.MusicEntry
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
@@ -15,8 +16,19 @@ class LastFMViewModel(
     val isAuthenticated: StateFlow<Boolean>
         get() = useCase.isAuthenticated
     val authenticating: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    val isScrobbling: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
     fun logout() = useCase.logout()
+
+    fun scrobble(selection: List<MusicEntry>) =
+        viewModelScope.launch {
+            isScrobbling.update { true }
+            try {
+                useCase.scrobble(selection)
+            } finally {
+                isScrobbling.update { false }
+            }
+        }
 
     fun authenticate(
         username: String,

--- a/composeApp/src/main/java/dev/igorcferreira/musicstreamsync/list/Entry.kt
+++ b/composeApp/src/main/java/dev/igorcferreira/musicstreamsync/list/Entry.kt
@@ -89,23 +89,19 @@ fun Entry(
                                 .clip(RoundedCornerShape(4.dp)),
                     )
                 }
-                Column(Modifier.padding(start = 8.dp)) {
+                Column(Modifier.padding(start = 8.dp, end = 8.dp)) {
                     Text(
                         entry.title,
                         modifier =
                             Modifier
                                 .fillMaxWidth()
-                                .padding(horizontal = 16.dp)
-                                .padding(top = 16.dp),
+                                .padding(top = 8.dp),
                         style = MaterialTheme.typography.bodyLarge,
                     )
                     entry.body?.let { body ->
                         Text(
                             body,
-                            modifier =
-                                Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = 16.dp),
+                            modifier = Modifier.fillMaxWidth(),
                             style = MaterialTheme.typography.bodyMedium,
                         )
                     }
@@ -115,7 +111,6 @@ fun Entry(
                             modifier =
                                 Modifier
                                     .fillMaxWidth()
-                                    .padding(horizontal = 16.dp)
                                     .padding(bottom = 8.dp),
                             style = MaterialTheme.typography.bodySmall,
                         )

--- a/composeApp/src/main/java/dev/igorcferreira/musicstreamsync/list/EntryList.kt
+++ b/composeApp/src/main/java/dev/igorcferreira/musicstreamsync/list/EntryList.kt
@@ -7,7 +7,9 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -23,19 +25,25 @@ import dev.igorcferreira.musicstreamsync.model.EntryData
 import dev.igorcferreira.musicstreamsync.model.MusicEntry
 import dev.igorcferreira.musicstreamsync.player.Player
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EntryList(
     items: List<EntryData>,
     loading: Boolean,
     entry: @Composable (EntryData) -> Unit,
     player: @Composable () -> Unit,
+    onRefresh: (() -> Unit)? = null,
+    header: (@Composable () -> Unit)? = null,
 ) {
     val context = LocalContext.current
 
-    Box(
-        Modifier
-            .background(MaterialTheme.colorScheme.background)
-            .fillMaxSize(),
+    PullToRefreshBox(
+        isRefreshing = loading,
+        onRefresh = { onRefresh?.invoke() },
+        modifier =
+            Modifier
+                .background(MaterialTheme.colorScheme.background)
+                .fillMaxSize(),
     ) {
         Column(
             Modifier
@@ -44,7 +52,7 @@ fun EntryList(
                 .align(Alignment.TopStart),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            AnimatedVisibility(loading) {
+            AnimatedVisibility(loading && onRefresh == null) {
                 CircularProgressIndicator(
                     modifier =
                         Modifier
@@ -66,6 +74,9 @@ fun EntryList(
                         .padding(16.dp),
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
+                    if (header != null) {
+                        item { header() }
+                    }
                     items(items) { entry ->
                         Row(modifier = Modifier.padding(bottom = 8.dp)) {
                             entry(entry)

--- a/composeApp/src/main/java/dev/igorcferreira/musicstreamsync/player/Player.kt
+++ b/composeApp/src/main/java/dev/igorcferreira/musicstreamsync/player/Player.kt
@@ -82,12 +82,12 @@ fun Player(
     Row(
         modifier
             .fillMaxWidth()
-            .background(MaterialTheme.colorScheme.secondary),
+            .background(MaterialTheme.colorScheme.secondary)
+            .navigationBarsPadding(),
     ) {
         Row(
             Modifier
                 .padding(all = 8.dp)
-                .padding(bottom = 20.dp)
                 .clickable {
                     if (isPlaying) pause(entry) else play(entry)
                 },

--- a/composeApp/src/main/java/dev/igorcferreira/musicstreamsync/playlist/Playlist.kt
+++ b/composeApp/src/main/java/dev/igorcferreira/musicstreamsync/playlist/Playlist.kt
@@ -1,12 +1,17 @@
 package dev.igorcferreira.musicstreamsync.playlist
 
+import android.content.res.Configuration
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.viewmodel.compose.viewModel
+import dev.igorcferreira.musicstreamsync.application.theme.AppTheme
 import dev.igorcferreira.musicstreamsync.di.ViewModelFactory
 import dev.igorcferreira.musicstreamsync.list.Entry
 import dev.igorcferreira.musicstreamsync.list.EntryList
+import dev.igorcferreira.musicstreamsync.model.PlaylistEntry
 import dev.igorcferreira.musicstreamsync.player.Player
 
 @Composable
@@ -18,5 +23,80 @@ fun Playlist(viewModel: PlaylistViewModel = viewModel(factory = ViewModelFactory
         viewModel.load()
     }
 
-    EntryList(items.value, loading.value, { Entry(it) }, { Player() })
+    EntryList(
+        items = items.value,
+        loading = loading.value,
+        entry = { Entry(it) },
+        player = { Player() },
+        onRefresh = { viewModel.load() },
+    )
+}
+
+@Preview(name = "Loading — Light", showBackground = true)
+@Composable
+fun PlaylistLoadingPreview() {
+    AppTheme {
+        EntryList(
+            items = listOf(),
+            loading = true,
+            entry = { Entry(Modifier, it) {} },
+            player = { Player(Modifier, null, false, {}, {}) },
+        )
+    }
+}
+
+@Preview(name = "Content — Light", showBackground = true)
+@Composable
+fun PlaylistContentPreview() {
+    AppTheme {
+        EntryList(
+            items =
+                listOf(
+                    PlaylistEntry(
+                        id = "p.abc123",
+                        entryId = null,
+                        name = "Heavy Rotation",
+                        canEdit = true,
+                        hasCatalog = false,
+                        isPublic = false,
+                        entryDescription = "My most-played tracks",
+                    ),
+                    PlaylistEntry(
+                        id = "p.def456",
+                        entryId = null,
+                        name = "Workout Mix",
+                        canEdit = true,
+                        hasCatalog = false,
+                        isPublic = true,
+                    ),
+                ),
+            loading = false,
+            entry = { Entry(Modifier, it) {} },
+            player = { Player(Modifier, null, false, {}, {}) },
+        )
+    }
+}
+
+@Preview(name = "Content — Dark", uiMode = Configuration.UI_MODE_NIGHT_YES, showBackground = true)
+@Composable
+fun PlaylistContentDarkPreview() {
+    AppTheme {
+        EntryList(
+            items =
+                listOf(
+                    PlaylistEntry(
+                        id = "p.abc123",
+                        entryId = null,
+                        name = "Heavy Rotation",
+                        canEdit = true,
+                        hasCatalog = false,
+                        isPublic = false,
+                        entryDescription = "My most-played tracks",
+                    ),
+                ),
+            loading = false,
+            entry = { Entry(Modifier, it) {} },
+            player = { Player(Modifier, null, false, {}, {}) },
+        )
+    }
 }

--- a/composeApp/src/main/java/dev/igorcferreira/musicstreamsync/scrobble/Scrobble.kt
+++ b/composeApp/src/main/java/dev/igorcferreira/musicstreamsync/scrobble/Scrobble.kt
@@ -1,0 +1,183 @@
+package dev.igorcferreira.musicstreamsync.scrobble
+
+import android.content.res.Configuration
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import dev.igorcferreira.musicstreamsync.R
+import dev.igorcferreira.musicstreamsync.application.theme.AppTheme
+import dev.igorcferreira.musicstreamsync.di.ViewModelFactory
+import dev.igorcferreira.musicstreamsync.list.Entry
+import dev.igorcferreira.musicstreamsync.list.EntryList
+import dev.igorcferreira.musicstreamsync.model.EntryData
+import dev.igorcferreira.musicstreamsync.model.MusicEntry
+
+@Composable
+fun Scrobble(viewModel: ScrobbleViewModel = viewModel(factory = ViewModelFactory.Scrobble)) {
+    val history = viewModel.history.collectAsState()
+    val loading = viewModel.loading.collectAsState()
+    val selection = viewModel.selection.collectAsState()
+
+    LaunchedEffect(Unit) { viewModel.updateHistory() }
+
+    Scrobble(
+        items = history.value,
+        loading = loading.value,
+        selection = selection.value,
+        onRefresh = { viewModel.updateHistory() },
+        onToggle = { viewModel.toggleSelection(it) },
+        isSelected = { viewModel.isSelected(it) },
+        onScrobble = { viewModel.scrobble() },
+    )
+}
+
+@Composable
+fun Scrobble(
+    items: List<EntryData>,
+    loading: Boolean,
+    selection: Set<String>,
+    onRefresh: () -> Unit,
+    onToggle: (EntryData) -> Unit,
+    isSelected: (EntryData) -> Boolean,
+    onScrobble: () -> Unit,
+) {
+    EntryList(
+        items = items,
+        loading = loading,
+        onRefresh = onRefresh,
+        header = {
+            AnimatedVisibility(!loading) {
+                Text(
+                    text = stringResource(R.string.scrobble_instructions),
+                    modifier = Modifier.padding(bottom = 8.dp),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+            AnimatedVisibility(selection.isNotEmpty()) {
+                Button(
+                    onClick = onScrobble,
+                    modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+                ) {
+                    Text(text = stringResource(R.string.scrobble))
+                }
+            }
+        },
+        entry = { entryData ->
+            Box {
+                Entry(
+                    modifier = Modifier,
+                    entry = entryData,
+                    onClick = { onToggle(entryData) },
+                )
+                if (isSelected(entryData)) {
+                    Box(
+                        Modifier
+                            .matchParentSize()
+                            .clip(RoundedCornerShape(8.dp))
+                            .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.33f))
+                            .clickable { onToggle(entryData) },
+                    )
+                }
+            }
+        },
+        player = {},
+    )
+}
+
+private val previewEntries: List<MusicEntry> =
+    listOf(
+        MusicEntry(
+            id = "1184710148",
+            title = "Stardust",
+            artist = "Delain",
+            artworkUrl = "",
+            album = "The Human Contradiction",
+        ),
+        MusicEntry(
+            id = "1184710149",
+            title = "Here Come the Vultures",
+            artist = "Delain",
+            artworkUrl = "",
+            album = "The Human Contradiction",
+        ),
+    )
+
+@Preview(name = "Loading — Light", showBackground = true)
+@Composable
+fun ScrobbleLoadingPreview() {
+    AppTheme {
+        Scrobble(
+            items = listOf(),
+            loading = true,
+            selection = emptySet(),
+            onRefresh = {},
+            onToggle = {},
+            isSelected = { false },
+            onScrobble = {},
+        )
+    }
+}
+
+@Preview(name = "Content — No Selection", showBackground = true)
+@Composable
+fun ScrobbleNoSelectionPreview() {
+    AppTheme {
+        Scrobble(
+            items = previewEntries,
+            loading = false,
+            selection = emptySet(),
+            onRefresh = {},
+            onToggle = {},
+            isSelected = { false },
+            onScrobble = {},
+        )
+    }
+}
+
+@Preview(name = "Content — With Selection", showBackground = true)
+@Composable
+fun ScrobbleWithSelectionPreview() {
+    AppTheme {
+        Scrobble(
+            items = previewEntries,
+            loading = false,
+            selection = setOf("1184710148"),
+            onRefresh = {},
+            onToggle = {},
+            isSelected = { it.id == "1184710148" },
+            onScrobble = {},
+        )
+    }
+}
+
+@Preview(name = "Content — Dark", uiMode = Configuration.UI_MODE_NIGHT_YES, showBackground = true)
+@Composable
+fun ScrobbleDarkPreview() {
+    AppTheme {
+        Scrobble(
+            items = previewEntries,
+            loading = false,
+            selection = setOf("1184710148"),
+            onRefresh = {},
+            onToggle = {},
+            isSelected = { it.id == "1184710148" },
+            onScrobble = {},
+        )
+    }
+}

--- a/composeApp/src/main/java/dev/igorcferreira/musicstreamsync/scrobble/ScrobbleViewModel.kt
+++ b/composeApp/src/main/java/dev/igorcferreira/musicstreamsync/scrobble/ScrobbleViewModel.kt
@@ -1,0 +1,49 @@
+package dev.igorcferreira.musicstreamsync.scrobble
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dev.igorcferreira.musicstreamsync.domain.use_cases.LastFMUseCase
+import dev.igorcferreira.musicstreamsync.domain.use_cases.RecentlyPlayedUseCase
+import dev.igorcferreira.musicstreamsync.model.EntryData
+import dev.igorcferreira.musicstreamsync.model.MusicEntry
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class ScrobbleViewModel(
+    private val lastFMUseCase: LastFMUseCase,
+    private val recentlyPlayedUseCase: RecentlyPlayedUseCase,
+) : ViewModel() {
+    val history: StateFlow<List<MusicEntry>>
+        get() = recentlyPlayedUseCase.result
+    val loading: StateFlow<Boolean>
+        get() = recentlyPlayedUseCase.isPerforming
+    val selection = MutableStateFlow<Set<String>>(emptySet())
+    val isScrobbling = MutableStateFlow(false)
+
+    fun updateHistory() =
+        viewModelScope.launch {
+            recentlyPlayedUseCase.perform()
+        }
+
+    fun toggleSelection(entry: EntryData) {
+        selection.update { current ->
+            if (entry.id in current) current - entry.id else current + entry.id
+        }
+    }
+
+    fun isSelected(entry: EntryData): Boolean = entry.id in selection.value
+
+    fun scrobble() =
+        viewModelScope.launch {
+            isScrobbling.update { true }
+            try {
+                val items = history.value.filter { it.id in selection.value }
+                lastFMUseCase.scrobble(items)
+                selection.update { emptySet() }
+            } finally {
+                isScrobbling.update { false }
+            }
+        }
+}

--- a/composeApp/src/main/res/values/strings.xml
+++ b/composeApp/src/main/res/values/strings.xml
@@ -9,4 +9,7 @@
     <string name="username">Username</string>
     <string name="password">Password</string>
     <string name="authenticate">Authenticate</string>
+    <string name="scrobble">Scrobble</string>
+    <string name="manual_scrobble">Manual Scrobble</string>
+    <string name="scrobble_instructions">Select the items to scrobble and then hit \'Scrobble\' to update your Last.fm library</string>
 </resources>


### PR DESCRIPTION
## Summary

- **Manual Scrobble tab**: adds a third tab (History / Playlists / **Scrobble**) matching the iOS ScrobbleView — shows recently-played tracks with multi-select, a tinted overlay on selected rows, and a Scrobble button that batch-scrobbles the selection to Last.fm
- **Pull-to-refresh**: History and Playlist lists now support drag-to-refresh via Material3 `PullToRefreshBox`, matching iOS `.refreshable` behaviour
- **Entry card padding**: removes the stacked `horizontal = 16.dp` padding on text items inside cards (was over-padded) and tightens the title top padding from 16 → 8 dp
- **Player navigation bar inset**: replaces the hardcoded `bottom = 20.dp` in the Player bar with `navigationBarsPadding()` so it adapts correctly to gesture-nav and button-nav devices
- **Composable previews**: adds `@Preview` functions to `App`, `History`, `Playlist`, `Scrobble`, and `LastFMToolbar` — covering loading, content, selection, light, and dark states; extracts a stateless `App` overload to decouple the chrome from ViewModel state

## Test plan

- [x] `./gradlew testAndroid` — passes
- [x] `./gradlew iosSimulatorArm64Test` — passes
- [x] `./gradlew :composeApp:assembleDebug` — builds clean
- [x] `./gradlew :composeApp:ktlintCheck` — no violations
- [ ] Manual: History and Playlist tabs load and pull-to-refresh works
- [ ] Manual: Scrobble tab — tap items to select (overlay appears), Scrobble button appears, tapping it clears selection
- [ ] Manual: Player bar bottom inset adapts on gesture-nav device
- [ ] Manual: Last.fm auth toolbar works from all three tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)