### PR TITLE
Spec: Kotlin sync server

### DIFF
--- a/spec/AGENT.md
+++ b/spec/AGENT.md
@@ -1,0 +1,98 @@
+# AGENT.md — Session protocol for the sync-server spec suite
+
+This folder contains the spec-driven task breakdown for building the MusicStreamSync
+**sync server**: a JVM process, built on the existing KMP shared code, that periodically
+fetches a user's Apple Music play history, diffs it against their Last.fm history, and
+scrobbles the delta. Read [README.md](README.md) first for the architecture, decisions,
+and task table.
+
+## Workflow (every session)
+
+1. Read [README.md](README.md): the task table is the single source of truth for status.
+2. Pick the next `pending` task whose **Depends on** entries are all `done` (PR merged).
+   Tasks with independently-merged dependencies may be worked **in parallel** on separate
+   branches.
+3. Read that task's `TASK_N_SPEC.md` in full. Implement **only** what the spec scopes.
+4. Validate (see [Validation commands](#validation-commands) and the task's own
+   Validation section).
+5. Update the task's row in `README.md` (status, branch, PR link) and append a one-line
+   entry to the Session log at the bottom of `README.md`.
+
+## Branch & PR mandate
+
+- `feature/kotlin_server` is the **central integration branch** — the current working
+  state. **Never commit task work directly to it.**
+- Each task is developed on its own branch cut from `feature/kotlin_server`, named
+  `task/<n>-<short-name>` (e.g. `task/1-shared-jvm-target`).
+- A task ends with a **PR targeting `feature/kotlin_server`**.
+- Status values in the README table:
+  `pending` → `in_progress` → `in_review` (PR open) → `done` (PR merged).
+- The README status update and PR link are committed on the task branch and land as part
+  of its PR.
+
+## `spec/PROGRESS.md` — per-branch work journal
+
+While working a task branch, keep session progress in `spec/PROGRESS.md`:
+
+- which task is being worked and its branch,
+- notes per session (what was done, what was tried and rejected),
+- decisions taken (and why) when the spec left room,
+- what remains before the task's acceptance criteria pass.
+
+This lets an interrupted session be resumed on that branch by a fresh session. The file
+is **branch-local scratch state**:
+
+- It MUST be deleted (deletion committed) **before the PR is opened**.
+- The GitHub Actions check `spec-progress-guard` fails any PR whose changes contain
+  `spec/PROGRESS.md`.
+
+## API documentation mandate (Swagger/OpenAPI)
+
+Every HTTP API created for consumption by the native apps MUST be documented in the
+single Swagger document **`server/openapi.yaml`** (created by TASK_3, served by the
+server at `GET /openapi.yaml`).
+
+- Any task that adds or changes an endpoint updates `server/openapi.yaml` **in the same
+  task**.
+- A task touching the HTTP surface is not `done` until the document matches the
+  implemented API (paths, schemas, auth scheme, error responses).
+
+## Docker mandate
+
+All `:server` development, testing, and deployment happens with Docker support:
+
+- The server runs via `docker compose up` (services: `server` + `mongodb`).
+- Server tasks must validate **inside the containerized environment**
+  (`docker compose build` + a smoke run against the container), not only via the host
+  Gradle build.
+
+## Rules
+
+- **Do not expand scope.** If something adjacent needs fixing, note it in the PR
+  description or add a follow-up line to the README, don't do it in the task branch.
+- **Specs are the source of truth.** If a spec conflicts with what you find in the code,
+  update the spec first (in the task branch), note the change in the PR, then implement.
+- Follow repo conventions: ktlint/SwiftLint clean, builds green before committing
+  (see the root `CLAUDE.md`).
+- Commit granularity: at least one commit per task; more is fine.
+
+## Validation commands
+
+All Gradle commands use JDK 17:
+
+```bash
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
+```
+
+| Check | Command |
+| --- | --- |
+| Kotlin lint | `./gradlew ktlintCheck` |
+| Android app builds | `./gradlew :composeApp:assembleDebug` |
+| Shared tests (Android host) | `./gradlew :shared:testAndroidHostTest` |
+| Shared tests (JVM, after TASK_1) | `./gradlew :shared:jvmTest` |
+| Last.fm module tests | `./gradlew :lastfmapi:jvmTest` |
+| Server tests (after TASK_3) | `./gradlew :server:test` |
+| iOS tests | `./gradlew iosSimulatorArm64Test` |
+| iOS app builds (tasks touching `iosApp/`) | `xcodebuild` / xcrun MCP tooling on `iosApp/iosApp.xcodeproj` |
+| Server container (tasks touching `:server`) | `docker compose build` + smoke run (`curl /health`) |
+| Swift lint (tasks touching Swift) | `swiftlint lint --config .swiftlint.yml` |

--- a/spec/AGENT.md
+++ b/spec/AGENT.md
@@ -20,11 +20,11 @@ and task table.
 
 ## Branch & PR mandate
 
-- `feature/kotlin_server` is the **central integration branch** — the current working
+- `feature/kotlin-server/base` is the **central integration branch** — the current working
   state. **Never commit task work directly to it.**
-- Each task is developed on its own branch cut from `feature/kotlin_server`, named
+- Each task is developed on its own branch cut from `feature/kotlin-server/base`, named
   `task/<n>-<short-name>` (e.g. `task/1-shared-jvm-target`).
-- A task ends with a **PR targeting `feature/kotlin_server`**.
+- A task ends with a **PR targeting `feature/kotlin-server/base`**.
 - Status values in the README table:
   `pending` → `in_progress` → `in_review` (PR open) → `done` (PR merged).
 - The README status update and PR link are committed on the task branch and land as part

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,104 @@
+# MusicStreamSync — Sync Server spec suite
+
+Orchestration file for building the **sync server**: a Kotlin/JVM process built on the
+existing KMP shared code that runs a cron-style loop to sync Apple Music play history
+into Last.fm, for multiple users. Working sessions follow the protocol in
+[AGENT.md](AGENT.md).
+
+## Problem statement
+
+The mobile apps only scrobble while they are running. The server closes that gap: on a
+time interval it fetches each registered user's Apple Music recently-played list,
+compares it with their Last.fm track history, and scrobbles the songs that are missing.
+
+Target behavior (the canonical scenario, encoded as acceptance tests in TASK_5):
+
+- User listens to Song A
+- User listens to Song B
+- Time passes. Cron job triggers → adds Song A and Song B to Last.fm history
+- User listens to Song C
+- Time passes. Cron job triggers → adds Song C to Last.fm history
+- User listens to Song A again
+- Time passes. Cron job triggers → adds Song A to Last.fm history
+- Time passes. Cron job triggers → adds nothing
+
+Apple Music has no server-side login or token refresh. The native apps therefore mint
+the **Music-User-Token** on-device and push it (together with the user's Last.fm session
+key) to the server.
+
+## Architecture
+
+```
+┌─────────────┐   ┌─────────────┐
+│ Android app │   │   iOS app   │      mint Music-User-Token on device
+│ (composeApp)│   │  (iosApp)   │      authenticate with Last.fm on device
+└──────┬──────┘   └──────┬──────┘
+       │  ServerSyncUseCase (shared, TASK_7)
+       │  PUT /api/users/tokens/apple-music
+       │  PUT /api/users/tokens/lastfm-session
+       ▼
+┌────────────────────────────────────────────────┐
+│ :server (Ktor, JVM, Docker)                    │
+│                                                │
+│  Token API (TASK_4) ──► UserStore ◄─┐          │
+│                          (MongoDB)  │          │
+│  Scheduler loop (TASK_6)            │          │
+│    for each registered user:        │          │
+│      SyncEngine.sync(user) (TASK_5)─┘          │
+│        │ getRecentlyPlayed()   │ diff + delta  │
+│        ▼                       ▼               │
+│  AppleMusicAPI (:shared jvm)  LastFMClient     │
+│        │        TASK_1        (:lastfmapi jvm) │
+└────────┼───────────────────────────┼───────────┘
+         ▼                           ▼
+   Apple Music API              Last.fm API
+   (recently played)       (getRecentTracks, scrobble)
+```
+
+## Decisions record
+
+| Decision | Choice |
+| --- | --- |
+| User model | **Multi-user**: one server instance serves many users. User id is resolved server-side from the Music-User-Token / Apple Music API (mechanism fixed in TASK_4, with a token-derived-hash fallback). |
+| Last.fm auth | **Apps push the session key** (apps authenticate on-device via `LastFMClient`, export the `Session`, upload it). No Last.fm credentials on the server. |
+| Persistence | **MongoDB** (docker-compose service, official Kotlin coroutine driver): per-user token, session, sync cursor, sync-run log. |
+| Environment | **Docker mandate**: dev and deploy via `Dockerfile` + `docker-compose.yml` (server + mongodb). |
+| API docs | **Swagger mandate**: single `server/openapi.yaml`, updated in the same task as any endpoint change. |
+| Branching | `feature/kotlin_server` is the integration branch; each task works on `task/<n>-<short-name>` and merges via PR. |
+
+## Task table
+
+Status values: `pending` / `in_progress` / `in_review` (PR open) / `done` (PR merged).
+
+| ID | Title | Depends on | Status | Branch | PR | Spec |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | `:shared` JVM target + actuals | — | pending | — | — | [TASK_1_SPEC.md](TASK_1_SPEC.md) |
+| 2 | lastfmapi session portability | — | pending | — | — | [TASK_2_SPEC.md](TASK_2_SPEC.md) |
+| 3 | `:server` scaffold + Docker environment | — | pending | — | — | [TASK_3_SPEC.md](TASK_3_SPEC.md) |
+| 4 | Multi-user token-sync API + persistence | 2, 3 | pending | — | — | [TASK_4_SPEC.md](TASK_4_SPEC.md) |
+| 5 | Sync engine (diff + scrobble) | 1, 2 | pending | — | — | [TASK_5_SPEC.md](TASK_5_SPEC.md) |
+| 6 | Scheduler loop + wiring | 4, 5 | pending | — | — | [TASK_6_SPEC.md](TASK_6_SPEC.md) |
+| 7 | Shared push use case (`ServerSyncUseCase`) | 2, 4 | pending | — | — | [TASK_7_SPEC.md](TASK_7_SPEC.md) |
+| 8 | Android app integration | 7 | pending | — | — | [TASK_8_SPEC.md](TASK_8_SPEC.md) |
+| 9 | iOS app integration | 7 | pending | — | — | [TASK_9_SPEC.md](TASK_9_SPEC.md) |
+
+### Dependency graph / parallelism
+
+```
+TASK_1 ─────────────┐
+TASK_2 ──┬──────────┼──► TASK_5 ──┐
+         │          │             ├──► TASK_6
+TASK_3 ──┴► TASK_4 ─┴─────────────┘
+                └─────► TASK_7 ──► TASK_8
+                                └► TASK_9
+```
+
+- Wave 1 (parallel): TASK_1 ∥ TASK_2 ∥ TASK_3
+- Wave 2 (parallel): TASK_4 (needs 2+3) ∥ TASK_5 (needs 1+2)
+- Wave 3: TASK_6 (needs 4+5) ∥ TASK_7 (needs 2+4)
+- Wave 4 (parallel): TASK_8 ∥ TASK_9 (need 7)
+
+## Session log
+
+<!-- One line per session: date — task — branch — what happened. -->
+- 2026-07-09 — spec suite created on `feature/kotlin_server`.

--- a/spec/README.md
+++ b/spec/README.md
@@ -78,24 +78,24 @@ Status values: `pending` / `in_progress` / `in_review` (PR open) / `done` (PR me
 | 4 | Multi-user token-sync API + persistence | 2, 3 | pending | — | — | [TASK_4_SPEC.md](TASK_4_SPEC.md) |
 | 5 | Sync engine (diff + scrobble) | 1, 2 | pending | — | — | [TASK_5_SPEC.md](TASK_5_SPEC.md) |
 | 6 | Scheduler loop + wiring | 4, 5 | pending | — | — | [TASK_6_SPEC.md](TASK_6_SPEC.md) |
-| 7 | Shared push use case (`ServerSyncUseCase`) | 2, 4 | pending | — | — | [TASK_7_SPEC.md](TASK_7_SPEC.md) |
+| 7 | Shared push use case (`ServerSyncUseCase`) | 1, 2, 4 | pending | — | — | [TASK_7_SPEC.md](TASK_7_SPEC.md) |
 | 8 | Android app integration | 7 | pending | — | — | [TASK_8_SPEC.md](TASK_8_SPEC.md) |
 | 9 | iOS app integration | 7 | pending | — | — | [TASK_9_SPEC.md](TASK_9_SPEC.md) |
 
 ### Dependency graph / parallelism
 
 ```
-TASK_1 ─────────────┐
-TASK_2 ──┬──────────┼──► TASK_5 ──┐
-         │          │             ├──► TASK_6
+TASK_1 ──┬──────────┬──► TASK_5 ──┐
+TASK_2 ──┼──────────┤             ├──► TASK_6
+         │          │             │
 TASK_3 ──┴► TASK_4 ─┴─────────────┘
                 └─────► TASK_7 ──► TASK_8
-                                └► TASK_9
+         (also needs 1, 2)      └► TASK_9
 ```
 
 - Wave 1 (parallel): TASK_1 ∥ TASK_2 ∥ TASK_3
 - Wave 2 (parallel): TASK_4 (needs 2+3) ∥ TASK_5 (needs 1+2)
-- Wave 3: TASK_6 (needs 4+5) ∥ TASK_7 (needs 2+4)
+- Wave 3: TASK_6 (needs 4+5) ∥ TASK_7 (needs 1+2+4)
 - Wave 4 (parallel): TASK_8 ∥ TASK_9 (need 7)
 
 ## Session log
@@ -103,3 +103,4 @@ TASK_3 ──┴► TASK_4 ─┴─────────────┘
 <!-- One line per session: date — task — branch — what happened. -->
 - 2026-07-09 — spec suite created (originally on `feature/kotlin_server`).
 - 2026-07-09 — restructured into `feature/kotlin-server/base` (integration) + `feature/kotlin-server/spec` (this plan-approval branch).
+- 2026-07-09 — senior Kotlin review of PR #81 applied: fixed internal-visibility design (SyncEngine → `:shared` jvmMain, public `Configuration` path), `Session.subscriber` wire shape, `HTTPException.code` exposure, top-K prefix cursor, Arkana JDK-21 Docker constraint, token-logging/cancellation hygiene, multi-device identity caveat, Mongo field-level update semantics.

--- a/spec/README.md
+++ b/spec/README.md
@@ -64,7 +64,7 @@ key) to the server.
 | Persistence | **MongoDB** (docker-compose service, official Kotlin coroutine driver): per-user token, session, sync cursor, sync-run log. |
 | Environment | **Docker mandate**: dev and deploy via `Dockerfile` + `docker-compose.yml` (server + mongodb). |
 | API docs | **Swagger mandate**: single `server/openapi.yaml`, updated in the same task as any endpoint change. |
-| Branching | `feature/kotlin_server` is the integration branch; each task works on `task/<n>-<short-name>` and merges via PR. |
+| Branching | `feature/kotlin-server/base` is the integration branch; each task works on `task/<n>-<short-name>` and merges via PR. |
 
 ## Task table
 
@@ -101,4 +101,5 @@ TASK_3 ──┴► TASK_4 ─┴─────────────┘
 ## Session log
 
 <!-- One line per session: date — task — branch — what happened. -->
-- 2026-07-09 — spec suite created on `feature/kotlin_server`.
+- 2026-07-09 — spec suite created (originally on `feature/kotlin_server`).
+- 2026-07-09 — restructured into `feature/kotlin-server/base` (integration) + `feature/kotlin-server/spec` (this plan-approval branch).

--- a/spec/TASK_1_SPEC.md
+++ b/spec/TASK_1_SPEC.md
@@ -4,9 +4,12 @@ Branch: `task/1-shared-jvm-target` · Depends on: — · Protocol: [AGENT.md](AG
 
 ## Goal
 
-Make `:shared` compile and test for plain JVM so the future `:server` module can reuse
-`AppleMusicAPI`, `Configuration`, the JWT developer-token signing, and the domain models
-without touching Android or iOS behavior.
+Make `:shared` compile and test for plain JVM so the sync-server work can reuse the
+Apple Music client, `Configuration`, the JWT developer-token signing, and the domain
+models without touching Android or iOS behavior. Note: `AppleMusicAPI` and `URLSession`
+are `internal` (module-scoped) — the server never touches them directly; the JVM-facing
+entry point is `SyncEngine` in `:shared` jvmMain (TASK_5) plus the public
+`Configuration` path added here.
 
 ## Context
 
@@ -25,10 +28,26 @@ without touching Android or iOS behavior.
   is jjwt-based and JVM-compatible **except** `String.clearKey()`, which uses
   `android.util.Base64`.
 - `URLSession` (`shared/src/commonMain/.../network/URLSession.kt`) builds a default-engine
-  Ktor `HttpClient`, so jvmMain needs a client engine dependency.
+  Ktor `HttpClient`, so jvmMain needs a client engine dependency. It currently
+  `println`s **all request headers (including `Authorization` and `Music-User-Token`)
+  and the full response body**, bypassing the `sanitizeHeader` config below it, and its
+  catch-all `catch (ex: Exception)` also swallows `CancellationException`.
+- `AppleMusicAPI` and `URLSession` are **`internal`**, and `Configuration`'s public
+  constructors (`model/Configuration.kt`) hard-call `createUserTokenProvider()` — there
+  is currently no public way to build a `Configuration` with an injected
+  `UserTokenProvider`, which the multi-user server needs (one provider per user).
+- `HTTPException` (`shared/src/commonMain/.../network/model/HTTPException.kt`) takes
+  `code: Int` as a plain constructor parameter and **discards it** (not a `val`) —
+  TASK_6's stale-token detection needs to read it.
 - Version catalog: `libs.ktor.client.okhttp`, `libs.jjwt.api` / `libs.jjwt.impl`
   (+ `jjwt-orgjson` runtime, see androidMain deps for the pattern), `libs.kotlin.test`,
-  `libs.kotlinx.coroutines.test` already exist in `gradle/libs.versions.toml`.
+  `libs.kotlinx.coroutines.test` already exist in `gradle/libs.versions.toml`. Note
+  `shared`'s `commonTest` already carries the jjwt trio.
+- Existing test to reuse:
+  `shared/src/androidHostTest/kotlin/dev/igorcferreira/musicstreamsync/model/JWTTokenSignerTests.kt`
+  (full ES256 sign + verify round-trip). `shared/src/androidHostTest/kotlin/android/util/Base64.kt`
+  is a shim of `android.util.Base64` onto `java.util.Base64` that becomes dead code once
+  `clearKey()` moves off `android.util.Base64` — delete it then.
 - The `swiftklib`/cinterop configuration is scoped to the iOS targets and must remain
   untouched. The `nativecoroutines` and `mokkery` plugins apply to all targets and are
   expected to work on JVM.
@@ -48,21 +67,38 @@ without touching Android or iOS behavior.
      reports `NOT_PLAYING`, emits no items. The server never uses the player; the stub
      exists only to satisfy the expect.
    - `MusicUserTokenProvider` / `createUserTokenProvider()` — a provider that wraps an
-     **injected/settable token** (e.g. a mutable `var token: String?` or
-     constructor-supplied lambda). `getUserToken()` throws a clear exception when no
-     token was injected. The server (TASK_4/5) constructs per-user
-     `AppleMusicAPI`/`Configuration` instances, each with its own provider instance.
-4. `JWTTokenSigner` available on JVM: extract the Android implementation into a source
+     **injected/settable token** (e.g. a mutable `var token: String?`). The expect
+     declares a **no-arg constructor**, so the JVM actual must actualize it (the iOS
+     actual is the precedent); a token-supplying constructor can only be an additional
+     one. `getUserToken()` throws a clear exception when no token was injected. The
+     JVM `createUserTokenProvider()` actual must **not** copy Android's singleton
+     pattern (`MusicUserTokenProvider.shared`) — the server needs one provider instance
+     per user, and a process-wide singleton silently breaks that.
+4. **Public per-user construction path:** a public `Configuration` constructor (or
+   factory) accepting a `UserTokenProvider` (e.g.
+   `Configuration(developerToken, tokenSigner, userTokenProvider)`), so the server can
+   build one `Configuration` per user without reaching for `internal` types.
+   `AppleMusicAPI`/`URLSession` stay `internal`.
+5. **`HTTPException` exposes its status:** change `code: Int` to `val code: Int`
+   (additive, binary-compatible for iOS/Android). TASK_6's 401/403 handling depends on
+   it.
+6. **`URLSession` hygiene:** remove the debug `println`s of request headers and response
+   bodies (the Ktor `Logging` plugin with its `sanitizeHeader` config stays), and make
+   the catch-all rethrow `CancellationException` instead of wrapping it in
+   `HTTPException`.
+7. `JWTTokenSigner` available on JVM: extract the Android implementation into a source
    set shared between `androidMain` and `jvmMain` (e.g. an intermediate `jvmCommon`
    source set), replacing `android.util.Base64` with `java.util.Base64` or
    `kotlin.io.encoding.Base64`. Behavior on Android must not change (the existing
    Base64 handling of the Arkana-encoded private key — decode wrapper, strip PEM
-   markers, decode content — must be preserved bit-for-bit).
-5. A `jvmTest` source set with at least: a `JWTTokenSigner` signing test (mirroring the
-   existing Android test if one exists, otherwise a new ES256 round-trip using jjwt's
-   parser) and a `MusicUserTokenProvider` injection test.
-6. No public API changes visible to iOS (the generated `MusicStream` framework surface
-   is unchanged) and no behavior changes on Android.
+   markers, decode content — must be preserved bit-for-bit). Delete the now-dead
+   `androidHostTest` `android.util.Base64` shim.
+8. A `jvmTest` source set with at least: a `JWTTokenSigner` signing test (port
+   `JWTTokenSignerTests.kt` from `androidHostTest`, reusable nearly verbatim) and a
+   `MusicUserTokenProvider` injection test.
+9. No breaking API changes visible to iOS (additive changes like the new `Configuration`
+   constructor and `HTTPException.code` are acceptable) and no behavior changes on
+   Android.
 
 ## Non-goals
 

--- a/spec/TASK_1_SPEC.md
+++ b/spec/TASK_1_SPEC.md
@@ -81,4 +81,4 @@ export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
 ./gradlew iosSimulatorArm64Test
 ```
 
-All must pass. Delete `spec/PROGRESS.md`, then open a PR to `feature/kotlin_server`.
+All must pass. Delete `spec/PROGRESS.md`, then open a PR to `feature/kotlin-server/base`.

--- a/spec/TASK_1_SPEC.md
+++ b/spec/TASK_1_SPEC.md
@@ -1,0 +1,84 @@
+# TASK_1 — Add a JVM target to `:shared`
+
+Branch: `task/1-shared-jvm-target` · Depends on: — · Protocol: [AGENT.md](AGENT.md)
+
+## Goal
+
+Make `:shared` compile and test for plain JVM so the future `:server` module can reuse
+`AppleMusicAPI`, `Configuration`, the JWT developer-token signing, and the domain models
+without touching Android or iOS behavior.
+
+## Context
+
+- `shared/build.gradle.kts` currently declares only `android` and the three iOS targets.
+  `:lastfmapi` and `:arkana` already have `jvm()` targets, so all of `:shared`'s
+  common dependencies resolve on JVM.
+- `commonMain` has 5 `expect` declarations that need JVM actuals:
+  1. `MusicUserTokenProvider` (class) — `shared/src/commonMain/kotlin/dev/igorcferreira/musicstreamsync/domain/UserTokenProvider.kt`
+  2. `createUserTokenProvider()` — same file
+  3. `SystemLogger` (object) — `shared/src/commonMain/kotlin/dev/igorcferreira/musicstreamsync/domain/SystemLogger.kt`
+  4. `MediaPlayerNativePlayer` (class) — `shared/src/commonMain/kotlin/dev/igorcferreira/musicstreamsync/domain/player/NativePlayer.kt`
+  5. `buildNativePlayer()` — same file
+  Reference implementations live in `shared/src/androidMain/.../domain/` and
+  `shared/src/iosMain/.../domain/`.
+- `JWTTokenSigner` (`shared/src/androidMain/kotlin/dev/igorcferreira/musicstreamsync/domain/JWTTokenSigner.kt`)
+  is jjwt-based and JVM-compatible **except** `String.clearKey()`, which uses
+  `android.util.Base64`.
+- `URLSession` (`shared/src/commonMain/.../network/URLSession.kt`) builds a default-engine
+  Ktor `HttpClient`, so jvmMain needs a client engine dependency.
+- Version catalog: `libs.ktor.client.okhttp`, `libs.jjwt.api` / `libs.jjwt.impl`
+  (+ `jjwt-orgjson` runtime, see androidMain deps for the pattern), `libs.kotlin.test`,
+  `libs.kotlinx.coroutines.test` already exist in `gradle/libs.versions.toml`.
+- The `swiftklib`/cinterop configuration is scoped to the iOS targets and must remain
+  untouched. The `nativecoroutines` and `mokkery` plugins apply to all targets and are
+  expected to work on JVM.
+
+## Requirements
+
+1. `jvm()` target added to `shared/build.gradle.kts` with `jvmTarget = JVM_17`
+   (matching the android target).
+2. `jvmMain` dependencies: a Ktor client engine (`libs.ktor.client.okhttp`), the jjwt
+   trio (api + impl + orgjson runtime, without the Android `org.json` exclusion), and
+   anything else required to compile.
+3. JVM actuals:
+   - `SystemLogger` — delegate to SLF4J if a logger dependency is already on the JVM
+     classpath via Ktor, otherwise `println` with the same tag/message/throwable shape
+     as the Android actual.
+   - `MediaPlayerNativePlayer` / `buildNativePlayer()` — inert stub: never plays,
+     reports `NOT_PLAYING`, emits no items. The server never uses the player; the stub
+     exists only to satisfy the expect.
+   - `MusicUserTokenProvider` / `createUserTokenProvider()` — a provider that wraps an
+     **injected/settable token** (e.g. a mutable `var token: String?` or
+     constructor-supplied lambda). `getUserToken()` throws a clear exception when no
+     token was injected. The server (TASK_4/5) constructs per-user
+     `AppleMusicAPI`/`Configuration` instances, each with its own provider instance.
+4. `JWTTokenSigner` available on JVM: extract the Android implementation into a source
+   set shared between `androidMain` and `jvmMain` (e.g. an intermediate `jvmCommon`
+   source set), replacing `android.util.Base64` with `java.util.Base64` or
+   `kotlin.io.encoding.Base64`. Behavior on Android must not change (the existing
+   Base64 handling of the Arkana-encoded private key — decode wrapper, strip PEM
+   markers, decode content — must be preserved bit-for-bit).
+5. A `jvmTest` source set with at least: a `JWTTokenSigner` signing test (mirroring the
+   existing Android test if one exists, otherwise a new ES256 round-trip using jjwt's
+   parser) and a `MusicUserTokenProvider` injection test.
+6. No public API changes visible to iOS (the generated `MusicStream` framework surface
+   is unchanged) and no behavior changes on Android.
+
+## Non-goals
+
+- No server module, no HTTP endpoints, no MongoDB (TASK_3/4).
+- No sync logic (TASK_5).
+- No changes to `:lastfmapi` (TASK_2).
+
+## Validation
+
+```bash
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
+./gradlew ktlintCheck
+./gradlew :shared:jvmTest
+./gradlew :shared:testAndroidHostTest
+./gradlew :composeApp:assembleDebug
+./gradlew iosSimulatorArm64Test
+```
+
+All must pass. Delete `spec/PROGRESS.md`, then open a PR to `feature/kotlin_server`.

--- a/spec/TASK_2_SPEC.md
+++ b/spec/TASK_2_SPEC.md
@@ -18,8 +18,18 @@ fully authenticated `LastFMClient` without ever seeing the user's password.
   - `isAuthenticated`, `listLatestTracks`, `scrobble`, `updateNowPlaying` all read the
     stored session through `API` / `settings.session`.
 - `Session` (`lastfmapi/src/commonMain/kotlin/dev/igorcferreira/lastfm/model/Session.kt`)
-  is already `@Serializable` (verify: it must serialize `name` and `key` for transport).
-- The module already targets `jvm()` — no build changes expected.
+  is `@Serializable data class Session(name, key, subscriber: Int)` — **`subscriber` is
+  required with no default**, so a `{name, key}` payload does not deserialize today.
+- `LastFMClient.scrobble` wraps **every** exception — including `CancellationException`
+  — into `HTTPException(InternalServerError)` (`LastFMClient.kt`, the catch in
+  `scrobble`), flattening real error codes to 500 and breaking structured concurrency.
+- `Track` (`model/Track.kt`) declares `@SerialName("date") val uts: TrackDate`
+  **non-nullable with no default**, but Last.fm's `user.getRecentTracks` returns the
+  currently-playing track *without* a `date` attribute (`@attr nowplaying`), so
+  `listLatestTracks()` throws `MissingFieldException` whenever the user is mid-listen.
+- The module already targets `jvm()` — no build changes expected, except adding
+  `com.russhwolf:multiplatform-settings-test` to `gradle/libs.versions.toml` (version
+  ref `multiplatformSettings` exists) if `MapSettings` is used for isolation/tests.
 - Consumers: TASK_4 (server imports a session per user), TASK_7 (apps export the session
   to upload it).
 
@@ -40,17 +50,32 @@ fully authenticated `LastFMClient` without ever seeing the user's password.
    `multiplatform-settings-test`, or an own trivial implementation) or make the imported
    session instance-scoped. Pick one, document it in KDoc, and cover it with a test
    (two clients with different sessions in one process don't cross-talk).
-4. `Session` stays `@Serializable` and its wire shape (`name`, `key`) is documented —
-   TASK_4 reuses it as the upload payload schema.
-5. Existing behavior unchanged: mobile flow (`authenticate` → stored in default
+4. **Wire shape:** give `Session.subscriber` a default (`subscriber: Int = 0`) so a
+   `{name, key}` payload deserializes, and document the full wire shape
+   (`name`, `key`, optional `subscriber`) — TASK_4 reuses it as the upload payload
+   schema and must match it in `openapi.yaml`.
+5. **Now-playing resilience:** make `Track`'s date field nullable (or defaulted) and
+   have `listLatestTracks()` tolerate/filter the timestamp-less now-playing entry.
+   Test with a `getRecentTracks` fixture containing an `@attr nowplaying` track —
+   without this, TASK_5's history cross-check fails exactly while the user is
+   listening.
+6. **Exception hygiene in `scrobble`:** rethrow `CancellationException` and preserve
+   the original `HTTPException` code instead of flattening everything to
+   `InternalServerError` — TASK_6 classifies failures by status code.
+7. Existing behavior unchanged: mobile flow (`authenticate` → stored in default
    `Settings`) keeps working; `logout()` clears whatever storage backs the client.
-6. iOS framework surface: new API must be usable from Swift (no `internal` leakage,
-   consider `@Throws` where needed) since TASK_7/9 call the export from shared/iOS code.
+8. Swift reachability: the `MusicStream` framework does **not** export `:lastfmapi`
+   (no `export(project(":lastfmapi"))` in `shared`'s framework block), so "usable from
+   Swift" means usable from shared commonMain code that is itself exported — the
+   export surface the apps actually consume is the `Scrobbler`/`LastFMUseCase` wrapper
+   that TASK_7 extends. Keep new API `public` in commonMain and free of `internal`
+   types in signatures.
 
 ## Non-goals
 
 - No server code, no HTTP transport (TASK_4/7 handle transport).
-- No changes to scrobbling or track-listing logic.
+- No changes to scrobbling or track-listing *behavior* beyond the error-handling and
+  now-playing fixes scoped above.
 
 ## Validation
 

--- a/spec/TASK_2_SPEC.md
+++ b/spec/TASK_2_SPEC.md
@@ -1,0 +1,68 @@
+# TASK_2 — Last.fm session portability (`:lastfmapi`)
+
+Branch: `task/2-lastfm-session-portability` · Depends on: — · Protocol: [AGENT.md](AGENT.md)
+
+## Goal
+
+Let a `Session` obtained on one device travel to another process: the apps authenticate
+with Last.fm on-device and **export** the session; the server **imports** it and uses a
+fully authenticated `LastFMClient` without ever seeing the user's password.
+
+## Context
+
+- `lastfmapi/src/commonMain/kotlin/dev/igorcferreira/lastfm/LastFMClient.kt`:
+  - `authenticate(username, password)` returns the `Session` and stores it via the
+    **internal** `Settings.session` extension (`API.SESSION_KEY`).
+  - The only public constructor is `LastFMClient(apiKey, secret)`, which uses the no-arg
+    `Settings()`; the `Settings`-taking constructor is `internal`.
+  - `isAuthenticated`, `listLatestTracks`, `scrobble`, `updateNowPlaying` all read the
+    stored session through `API` / `settings.session`.
+- `Session` (`lastfmapi/src/commonMain/kotlin/dev/igorcferreira/lastfm/model/Session.kt`)
+  is already `@Serializable` (verify: it must serialize `name` and `key` for transport).
+- The module already targets `jvm()` — no build changes expected.
+- Consumers: TASK_4 (server imports a session per user), TASK_7 (apps export the session
+  to upload it).
+
+## Requirements
+
+1. **Export:** a public way to read the currently stored session, e.g.
+   `val LastFMClient.currentSession: Session?` or `fun currentSession(): Session?`.
+   Returns `null` when not authenticated.
+2. **Import:** a public way to build/restore an authenticated client from a transported
+   session, e.g. `fun LastFMClient.restoreSession(session: Session)` and/or a public
+   factory `LastFMClient(apiKey, secret, session)`. After import,
+   `isAuthenticated == true` and `listLatestTracks()`/`scrobble()` use the imported
+   session key exactly as if `authenticate()` had run locally.
+3. **Isolation for multi-user servers:** the server will hold one client per user in one
+   process. The no-arg `Settings()` is process-global, so restored sessions must not
+   collide: either make the `Settings`-taking constructor public (server passes an
+   in-memory `Settings` per user, e.g. `MapSettings` from
+   `multiplatform-settings-test`, or an own trivial implementation) or make the imported
+   session instance-scoped. Pick one, document it in KDoc, and cover it with a test
+   (two clients with different sessions in one process don't cross-talk).
+4. `Session` stays `@Serializable` and its wire shape (`name`, `key`) is documented —
+   TASK_4 reuses it as the upload payload schema.
+5. Existing behavior unchanged: mobile flow (`authenticate` → stored in default
+   `Settings`) keeps working; `logout()` clears whatever storage backs the client.
+6. iOS framework surface: new API must be usable from Swift (no `internal` leakage,
+   consider `@Throws` where needed) since TASK_7/9 call the export from shared/iOS code.
+
+## Non-goals
+
+- No server code, no HTTP transport (TASK_4/7 handle transport).
+- No changes to scrobbling or track-listing logic.
+
+## Validation
+
+```bash
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
+./gradlew ktlintCheck
+./gradlew :lastfmapi:jvmTest          # includes the new round-trip + isolation tests
+./gradlew :composeApp:assembleDebug
+./gradlew iosSimulatorArm64Test
+```
+
+Required test: **round-trip** — authenticate against a faked `API`/`Settings` (or inject
+a prebuilt `Session`), export, import into a fresh client, assert
+`isAuthenticated == true` and that a scrobble call signs with the imported key.
+Delete `spec/PROGRESS.md`, then open a PR to `feature/kotlin_server`.

--- a/spec/TASK_2_SPEC.md
+++ b/spec/TASK_2_SPEC.md
@@ -65,4 +65,4 @@ export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
 Required test: **round-trip** — authenticate against a faked `API`/`Settings` (or inject
 a prebuilt `Session`), export, import into a fresh client, assert
 `isAuthenticated == true` and that a scrobble call signs with the imported key.
-Delete `spec/PROGRESS.md`, then open a PR to `feature/kotlin_server`.
+Delete `spec/PROGRESS.md`, then open a PR to `feature/kotlin-server/base`.

--- a/spec/TASK_3_SPEC.md
+++ b/spec/TASK_3_SPEC.md
@@ -1,0 +1,77 @@
+# TASK_3 — `:server` module scaffold + Docker environment
+
+Branch: `task/3-server-scaffold` · Depends on: — · Protocol: [AGENT.md](AGENT.md)
+
+## Goal
+
+Stand up the `:server` Gradle module (Ktor server, JVM) with configuration, health
+check, the single Swagger document, and the Docker environment that all later server
+tasks build on. **Docker is the primary dev/deploy environment** for this module.
+
+## Context
+
+- Register the module in `settings.gradle.kts` (follow the existing `include(":…")`
+  list).
+- The version catalog (`gradle/libs.versions.toml`) has Ktor 3.5.1 **client** artifacts
+  only. Add server artifacts on the same `ktor` version ref:
+  `ktor-server-core`, `ktor-server-netty`, `ktor-server-content-negotiation`,
+  `ktor-serialization-kotlinx-json`, plus `logback-classic` and
+  `mongodb-driver-kotlin-coroutine` (and `ktor-server-test-host` for tests).
+- Dependencies: `:shared` (JVM target from TASK_1 — if TASK_1 isn't merged yet, this
+  task may scaffold without depending on `:shared` and leave a TODO wired in TASK_5),
+  `:lastfmapi`, `:arkana` (JVM-ready; provides `teamId`/`keyId`/`privateKey`/
+  `lastFMAPIKey`/`lastFMAPISecret` — requires `arkana -l kotlin` before building, see
+  root `CLAUDE.md`).
+- Build convention: JDK 17, ktlint (`alias(libs.plugins.ktlint)` like the other
+  modules).
+
+## Requirements
+
+1. **Module:** `server/build.gradle.kts` — Kotlin JVM (not multiplatform), application
+   plugin with a `mainClass`, ktlint applied, JVM toolchain/target 17.
+2. **Application:** Ktor server (Netty) entry point with:
+   - JSON content negotiation (kotlinx-serialization).
+   - Config from environment variables (with defaults where sane):
+     `PORT` (default 8080), `MONGODB_URI` (default
+     `mongodb://mongodb:27017/musicstreamsync`), `SYNC_SHARED_SECRET` (no default —
+     fail fast with a clear message when unset), `SYNC_INTERVAL_MINUTES` (default 5;
+     consumed by TASK_6).
+   - Structured logging via logback (console appender, no file appender).
+3. **MongoDB client:** created at startup from `MONGODB_URI` (official Kotlin coroutine
+   driver), exposed to routes via DI-by-constructor (no service-locator framework).
+4. **`GET /health`:** returns 200 with `{ "status": "ok", "mongo": true|false }`, where
+   `mongo` reflects a live ping to the database. Unauthenticated.
+5. **Swagger document:** create `server/openapi.yaml` (OpenAPI 3.x) — servers, the
+   bearer shared-secret `securityScheme` (used from TASK_4 on), and the `/health` path.
+   Serve the file at `GET /openapi.yaml`. This is the **single** API document all later
+   tasks extend (see the mandate in [AGENT.md](AGENT.md)).
+6. **Docker:**
+   - `server/Dockerfile`: multi-stage — stage 1 builds with a Gradle + JDK 17 image
+     (`gradle :server:installDist` or shadow jar; note the Arkana generation step),
+     stage 2 runs on a slim JRE 17 image as a non-root user.
+   - `docker-compose.yml` (repo root): services `server` (build from `server/Dockerfile`,
+     ports `8080:8080`, env from `.env`/environment) and `mongodb` (official `mongo`
+     image, named volume for `/data/db`). Server depends_on mongodb.
+   - Secrets/config flow through env vars; document them in `server/README.md` along
+     with `docker compose up` usage.
+7. **Tests:** `:server:test` with Ktor `testApplication` covering `/health` (mongo up →
+   `mongo: true` via a fake/ping stub; mongo unreachable → still 200 with
+   `mongo: false` or 503 — pick one, document it in `openapi.yaml`).
+
+## Non-goals
+
+- No token endpoints, no `UserStore` (TASK_4).
+- No sync engine or scheduler (TASK_5/6).
+
+## Validation
+
+```bash
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
+./gradlew ktlintCheck
+./gradlew :server:test
+./gradlew :composeApp:assembleDebug        # repo stays green
+docker compose build
+docker compose up -d && curl -fsS localhost:8080/health && curl -fsS localhost:8080/openapi.yaml && docker compose down
+```
+
+Delete `spec/PROGRESS.md`, then open a PR to `feature/kotlin_server`.

--- a/spec/TASK_3_SPEC.md
+++ b/spec/TASK_3_SPEC.md
@@ -74,4 +74,4 @@ docker compose build
 docker compose up -d && curl -fsS localhost:8080/health && curl -fsS localhost:8080/openapi.yaml && docker compose down
 ```
 
-Delete `spec/PROGRESS.md`, then open a PR to `feature/kotlin_server`.
+Delete `spec/PROGRESS.md`, then open a PR to `feature/kotlin-server/base`.

--- a/spec/TASK_3_SPEC.md
+++ b/spec/TASK_3_SPEC.md
@@ -46,9 +46,16 @@ tasks build on. **Docker is the primary dev/deploy environment** for this module
    Serve the file at `GET /openapi.yaml`. This is the **single** API document all later
    tasks extend (see the mandate in [AGENT.md](AGENT.md)).
 6. **Docker:**
-   - `server/Dockerfile`: multi-stage — stage 1 builds with a Gradle + JDK 17 image
+   - `server/Dockerfile`: multi-stage — stage 1 builds with a Gradle + **JDK 21** image
      (`gradle :server:installDist` or shadow jar; note the Arkana generation step),
-     stage 2 runs on a slim JRE 17 image as a non-root user.
+     stage 2 runs on a slim **JRE 21** image as a non-root user.
+     **Why 21, not 17:** the generated `arkana/build.gradle.kts` declares
+     `jvmToolchain(21)` (DO NOT MODIFY header) and `settings.gradle.kts` has no
+     toolchain resolver (no foojay), so a JDK-17-only container cannot provision 21 and
+     the build fails; a JRE 17 runtime would then throw `UnsupportedClassVersionError`
+     loading Arkana classes (`:server` depends on `:arkana` directly and via `:shared`'s
+     `api(project(":arkana"))`). The other modules target 17 bytecode, which runs fine
+     on 21.
    - `docker-compose.yml` (repo root): services `server` (build from `server/Dockerfile`,
      ports `8080:8080`, env from `.env`/environment) and `mongodb` (official `mongo`
      image, named volume for `/data/db`). Server depends_on mongodb.

--- a/spec/TASK_4_SPEC.md
+++ b/spec/TASK_4_SPEC.md
@@ -11,8 +11,9 @@ MongoDB. This API is the contract TASK_7 (shared client use case) consumes.
 ## Context
 
 - Server scaffold, Mongo client, env config, and `server/openapi.yaml` exist (TASK_3).
-- `Session` is `@Serializable` with `name` + `key` and importable into a `LastFMClient`
-  (TASK_2).
+- `Session` is `@Serializable` with `name`, `key`, and `subscriber` (defaulted to 0 by
+  TASK_2 — the wire shape documented there is authoritative) and importable into a
+  `LastFMClient` (TASK_2).
 - **User identity:** Apple provides no server-side login; the Music-User-Token is the
   only credential. The public Apple Music API has no obvious "get user id" endpoint, so
   this task must fix the mechanism:
@@ -26,19 +27,30 @@ MongoDB. This API is the contract TASK_7 (shared client use case) consumes.
      a client-generated install id) so the server can migrate the document. Record the
      chosen mechanism in this spec file (update it in the task branch) and in
      `server/openapi.yaml` descriptions.
+  3. *Multi-device caveat:* Music-User-Tokens are minted **per device**, so the same
+     person on Android + iOS yields two token hashes → two user documents syncing the
+     same accounts (duplicate-scrobble risk). The investigation must explicitly
+     consider keying — or at least deduplicating/merging — users by the Last.fm session
+     `name` once it is pushed (the one stable cross-device identifier the server
+     receives), and document the residual risk if not adopted.
 
 ## Requirements
 
 1. **`UserStore` repository** (constructor-injected `MongoDatabase`, coroutine driver),
    `users` collection keyed by user id, document fields:
    - `userId` (string, see identity mechanism), `musicUserToken` (string),
-     `lastFmSession` (`{ name, key }`, nullable until pushed),
-     `syncCursor` (nullable string — `lastSyncedHeadEntryId`, written by TASK_5),
+     `lastFmSession` (the TASK_2 `Session` wire shape, nullable until pushed),
+     `syncCursor` (nullable **ordered list of entryIds** — the top-K prefix cursor
+     defined in TASK_5, written by TASK_5),
      `tokenStale` (bool, default false), `createdAt`/`updatedAt`,
      `lastSync` (nullable: `{ at, result, scrobbledCount, error? }`),
      `syncLog` (capped list of recent run summaries).
    - Suspend CRUD used by this task + TASK_5/6: upsert user, get by id, list all,
      update cursor, mark token stale, append sync-run log.
+   - **Update semantics:** all writes are field-level (`$set` / `$setOnInsert`), never
+     whole-document replaces. A token push must never touch `syncCursor`, `lastSync`,
+     or `syncLog` — the API handlers race the scheduler loop (TASK_6), and per-field
+     atomic updates are the concurrency answer.
 2. **Auth:** all `/api/*` routes require `Authorization: Bearer <SYNC_SHARED_SECRET>`
    (constant-time comparison). 401 otherwise. The acting user is resolved from the
    `Music-User-Token` header sent with each request (the identity mechanism above) —
@@ -49,7 +61,8 @@ MongoDB. This API is the contract TASK_7 (shared client use case) consumes.
      user id, upserts the user document (migrating from `previousTokenHash` when
      present), clears `tokenStale`. 200 → `{ "userId": "..." }`.
    - `PUT /api/users/tokens/lastfm-session` — headers: bearer secret +
-     `Music-User-Token`; body: the serialized `Session` (`{ "name": "...", "key": "..." }`).
+     `Music-User-Token`; body: the serialized `Session` per TASK_2's wire shape
+     (`{ "name": "...", "key": "...", "subscriber": 0? }`).
      404 if the user isn't registered yet. 200 on stored.
    - `GET /api/users/status` — headers: bearer secret + `Music-User-Token`. Returns
      `{ "userId", "registered": true, "hasLastFmSession", "tokenStale", "lastSync": {...}? }`;

--- a/spec/TASK_4_SPEC.md
+++ b/spec/TASK_4_SPEC.md
@@ -86,4 +86,4 @@ curl -fsS -X PUT localhost:8080/api/users/tokens/apple-music \
 docker compose down
 ```
 
-Delete `spec/PROGRESS.md`, then open a PR to `feature/kotlin_server`.
+Delete `spec/PROGRESS.md`, then open a PR to `feature/kotlin-server/base`.

--- a/spec/TASK_4_SPEC.md
+++ b/spec/TASK_4_SPEC.md
@@ -1,0 +1,89 @@
+# TASK_4 — Multi-user token-sync API + MongoDB persistence
+
+Branch: `task/4-token-sync-api` · Depends on: TASK_2, TASK_3 · Protocol: [AGENT.md](AGENT.md)
+
+## Goal
+
+Give the native apps a server API to register users and push their credentials: the
+Apple Music **Music-User-Token** and the Last.fm **session**. Persist per-user state in
+MongoDB. This API is the contract TASK_7 (shared client use case) consumes.
+
+## Context
+
+- Server scaffold, Mongo client, env config, and `server/openapi.yaml` exist (TASK_3).
+- `Session` is `@Serializable` with `name` + `key` and importable into a `LastFMClient`
+  (TASK_2).
+- **User identity:** Apple provides no server-side login; the Music-User-Token is the
+  only credential. The public Apple Music API has no obvious "get user id" endpoint, so
+  this task must fix the mechanism:
+  1. *Investigate first:* whether any Apple Music API response reachable with the token
+     yields a stable per-user identifier (e.g. a `meta`/library identifier; the
+     storefront endpoint `GET /v1/me/storefront` identifies the region, not the user).
+  2. *Fallback (must be implemented regardless, used when no API id exists):* a
+     token-derived identifier — SHA-256 hash of the Music-User-Token. Document the
+     consequence: if Apple rotates the token, the hash changes and the upload creates a
+     new user document; mitigate by having the apps send their previous token hash (or
+     a client-generated install id) so the server can migrate the document. Record the
+     chosen mechanism in this spec file (update it in the task branch) and in
+     `server/openapi.yaml` descriptions.
+
+## Requirements
+
+1. **`UserStore` repository** (constructor-injected `MongoDatabase`, coroutine driver),
+   `users` collection keyed by user id, document fields:
+   - `userId` (string, see identity mechanism), `musicUserToken` (string),
+     `lastFmSession` (`{ name, key }`, nullable until pushed),
+     `syncCursor` (nullable string — `lastSyncedHeadEntryId`, written by TASK_5),
+     `tokenStale` (bool, default false), `createdAt`/`updatedAt`,
+     `lastSync` (nullable: `{ at, result, scrobbledCount, error? }`),
+     `syncLog` (capped list of recent run summaries).
+   - Suspend CRUD used by this task + TASK_5/6: upsert user, get by id, list all,
+     update cursor, mark token stale, append sync-run log.
+2. **Auth:** all `/api/*` routes require `Authorization: Bearer <SYNC_SHARED_SECRET>`
+   (constant-time comparison). 401 otherwise. The acting user is resolved from the
+   `Music-User-Token` header sent with each request (the identity mechanism above) —
+   no separate account/password system.
+3. **Endpoints** (JSON, documented in `server/openapi.yaml` in this same task):
+   - `PUT /api/users/tokens/apple-music` — headers: bearer secret; body:
+     `{ "musicUserToken": "...", "previousTokenHash": "...?" }`. Resolves/derives the
+     user id, upserts the user document (migrating from `previousTokenHash` when
+     present), clears `tokenStale`. 200 → `{ "userId": "..." }`.
+   - `PUT /api/users/tokens/lastfm-session` — headers: bearer secret +
+     `Music-User-Token`; body: the serialized `Session` (`{ "name": "...", "key": "..." }`).
+     404 if the user isn't registered yet. 200 on stored.
+   - `GET /api/users/status` — headers: bearer secret + `Music-User-Token`. Returns
+     `{ "userId", "registered": true, "hasLastFmSession", "tokenStale", "lastSync": {...}? }`;
+     404 when unknown.
+4. **Validation/errors:** malformed bodies → 400 with a JSON error shape (define it once
+   in `openapi.yaml` and reuse); secrets never logged; Music-User-Token only ever logged
+   as its hash.
+5. **OpenAPI:** `server/openapi.yaml` updated with the three paths, request/response
+   schemas (reuse the `Session` shape), the bearer scheme, and error responses. Task is
+   not done until the document matches the routes.
+6. **Tests:** Ktor `testApplication` route tests against an in-memory `UserStore` fake
+   (interface + fake) for auth, happy paths, 400/401/404; plus `UserStore` integration
+   tests against a real Mongo (Testcontainers, or the compose `mongodb` service with a
+   test profile) covering upsert/migration/cursor update.
+
+## Non-goals
+
+- No sync execution (TASK_5/6) — this task only stores state.
+- No client-side code (TASK_7).
+- No admin/list-users endpoint (add a follow-up task if needed).
+
+## Validation
+
+```bash
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
+./gradlew ktlintCheck
+./gradlew :server:test
+docker compose build
+docker compose up -d
+# smoke: register a user, push a session, read status (use a test secret from .env)
+curl -fsS -X PUT localhost:8080/api/users/tokens/apple-music \
+  -H "Authorization: Bearer $SYNC_SHARED_SECRET" -H "Content-Type: application/json" \
+  -d '{"musicUserToken":"smoke-token"}'
+docker compose down
+```
+
+Delete `spec/PROGRESS.md`, then open a PR to `feature/kotlin_server`.

--- a/spec/TASK_5_SPEC.md
+++ b/spec/TASK_5_SPEC.md
@@ -17,63 +17,82 @@ C → C; A again → A; nothing new → nothing).
   list of tracks with **no play timestamps**. A re-listen moves the track to the head.
   Diffing must therefore be **order-based against a persisted cursor**, not
   timestamp-based.
+- **Visibility constraint:** `AppleMusicAPI` and `URLSession` are `internal` to
+  `:shared` — a separate `:server` module cannot reference them. That is why
+  `SyncEngine` lives in `:shared` **jvmMain** (see Req 1), where `internal` symbols are
+  visible; `:server` (TASK_6) consumes only `SyncEngine`'s public surface. Per-user
+  construction goes through the public `Configuration(developerToken, tokenSigner,
+  userTokenProvider)` path added by TASK_1.
 - `MusicEntry.id` is index-prefixed by the mapper (`"${index}_$id"`); the stable track
-  identifier is **`MusicEntry.entryId`** — cursors must use `entryId`.
+  identifier is **`MusicEntry.entryId`** — cursors must use `entryId`. Note `entryId`
+  is declared `String?` (always non-null from the recently-played mapper, but the diff
+  code must handle the type — e.g. skip/log entries with null `entryId`).
 - `MusicEntry.duration` is in **seconds** (mapped from Apple's `durationInMillis`).
 - `LastFMClient.listLatestTracks(user)` returns `List<Track>` (name, artist, album,
   `date: Instant`). `LastFMClient.scrobble(items: List<Scrobble>)` batch-scrobbles;
   `Scrobble` carries track/artist/timestamp/album/albumArtist.
-- Per-user state comes from TASK_4's `UserStore` (`syncCursor` =
-  `lastSyncedHeadEntryId`, sync-run log). If TASK_4 is not merged yet, define a
-  minimal `SyncStateRepository` interface here and let TASK_6 bind it to `UserStore`.
+- Per-user state comes from TASK_4's `UserStore` (`syncCursor` = the top-K prefix
+  cursor below, sync-run log). Define a minimal `SyncStateRepository` interface in this
+  task (TASK_4 need not be merged) and let TASK_6 bind it to `UserStore`.
 - Existing mobile scrobbling (`shared/.../domain/Scrobbler.kt`) scrobbles at
   `Clock.System.now()` — the server may double-report plays the app already scrobbled;
   hence the Last.fm cross-check below.
 
 ## Requirements
 
-1. **`SyncEngine`** — a pure, constructor-injected class (location: `:server` main
-   source set, or `:shared` jvmMain if reuse is expected; prefer `:server` for
-   testability with Mokkery/fakes):
-   `SyncEngine(appleMusicAPI, lastFMClient, stateRepository, clock)` with a single
-   entry point `suspend fun sync(userId: String): SyncResult`.
-2. **Diff algorithm (order-based cursor):**
+1. **`SyncEngine`** — a pure, constructor-injected **public** class in `:shared`
+   **jvmMain** (it needs visibility of the `internal` `AppleMusicAPI`; see Context):
+   `SyncEngine(configuration, lastFMClient, stateRepository, clock)` with a single
+   entry point `suspend fun sync(userId: String): SyncResult`. Only public types in its
+   signatures, so `:server` (TASK_6) can drive it.
+2. **Diff algorithm (top-K prefix cursor):**
    - Fetch the Apple recent list (newest first).
-   - New plays = entries from the head **until** the entry whose `entryId` equals the
-     persisted `lastSyncedHeadEntryId` (exclusive).
-   - A re-listen of an already-synced song appears before the old head and is therefore
-     detected (satisfies the "Song A again" step of the scenario).
+   - The persisted cursor is the **ordered list of the top K entryIds** from the last
+     successful run (K = 10, constant).
+   - New plays = entries from the head until the **longest prefix match**: the first
+     position where the remainder of the fetched list aligns with the stored cursor
+     sequence. A single-id cursor is wrong here: with cursor `[A]` and plays C then A,
+     Apple returns `[A, C, …]` and cutting at `A` (index 0) would silently drop both
+     plays; matching against the K-sequence recovers such reorderings.
+   - A re-listen of an already-synced song appears before the matched prefix and is
+     therefore detected (satisfies the "Song A again" step of the scenario).
 3. **Double-scrobble guard:** before scrobbling, fetch `listLatestTracks()` and drop any
    candidate whose (artist, title) — case-insensitive — already appears in Last.fm
-   history within a recent window (default: since the last successful sync time, falling
-   back to the last N=50 scrobbles on first run). This protects against plays the mobile
-   apps already scrobbled in real time.
+   history within a recent window (since the last successful sync time; when no
+   last-sync time is recorded, fall back to the returned page — note
+   `listLatestTracks()` has **no limit parameter**, it returns Last.fm's default page
+   size, so a heavy listener can outrun the window). This protects against plays the
+   mobile apps already scrobbled in real time.
 4. **Scrobbling:** submit the remaining candidates in **chronological order** (reverse
    of Apple's list) via one batch `scrobble()` call. Apple provides no timestamps, so
    synthesize them backwards from `clock.now()`: the newest candidate gets `now`, each
    previous one gets the next one's timestamp minus that track's duration (fallback 3
    minutes when duration is 0). Timestamps must be strictly increasing in the submitted
    batch and never in the future.
-5. **Cursor update:** persist the new head `entryId` **only after** the scrobble batch
+5. **Cursor update:** persist the new top-K cursor **only after** the scrobble batch
    succeeds (or when there was nothing to scrobble). A failed scrobble leaves the cursor
    untouched so the next run retries.
 6. **Edge cases (all spec'd behavior, all tested):**
-   - *First run (no cursor):* initialize the cursor to the current head **without
+   - *First run (no cursor):* initialize the cursor to the current top-K **without
      scrobbling** (history before registration is not replayed).
-   - *Cursor not found in the fetched page* (more plays than the page size since last
+   - *No prefix match in the fetched page* (more plays than the page size since last
      run): treat the entire page as new plays.
    - *Empty Apple list* or *empty diff:* no-op, still records a sync-run log entry.
-   - *Known limitation (document in KDoc + README if not already):* an immediate repeat
-     of the current head track between two runs does not change the list head and is
-     undetectable — the play is lost. Accepted.
+   - *Known limitation (document in KDoc + in this spec):* an immediate repeat of the
+     current head track between two runs does not change the list order and is
+     undetectable — that play is lost. More generally, any sequence of re-listens that
+     reproduces a previous list prefix is ambiguous; the top-K prefix match reduces the
+     loss to these genuinely ambiguous cases. Accepted.
 7. **`SyncResult`** value type: counts (candidates, dropped-by-guard, scrobbled), new
    cursor, error info — consumed by TASK_6 for the sync-run log and `/api/users/status`.
 8. **Tests** (Mokkery mocks or hand-rolled fakes for `AppleMusicAPI`, `LastFMClient`,
    repository; virtual clock):
    - The **full canonical scenario** from README as a sequence of `sync()` calls:
      A,B → scrobbles [A,B]; +C → [C]; +A → [A]; unchanged → [].
-   - First-run initialization; cursor-missing-from-page; guard drops an app-scrobbled
-     track; scrobble failure leaves cursor untouched; timestamp synthesis ordering.
+   - First-run initialization; no-prefix-match page overflow; **cursor-track re-listen**
+     (cursor `[A, …]`, plays C then A → both C and A scrobbled); guard drops an
+     app-scrobbled track; scrobble failure leaves cursor untouched; timestamp synthesis
+     ordering; now-playing entry present in Last.fm history (TASK_2 fixture).
 
 ## Non-goals
 
@@ -87,7 +106,7 @@ C → C; A again → A; nothing new → nothing).
 ```bash
 export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
 ./gradlew ktlintCheck
-./gradlew :server:test        # or :shared:jvmTest if the engine lands in shared
+./gradlew :shared:jvmTest
 ./gradlew :composeApp:assembleDebug
 ```
 

--- a/spec/TASK_5_SPEC.md
+++ b/spec/TASK_5_SPEC.md
@@ -1,0 +1,94 @@
+# TASK_5 — Sync engine (diff Apple Music history → scrobble delta)
+
+Branch: `task/5-sync-engine` · Depends on: TASK_1, TASK_2 · Protocol: [AGENT.md](AGENT.md)
+
+## Goal
+
+The core logic: for **one user**, fetch the Apple Music recently-played list, determine
+which plays are new since the last run, and scrobble them to Last.fm — exactly
+reproducing the canonical scenario in [README.md](README.md) (Songs A/B → A+B scrobbled;
+C → C; A again → A; nothing new → nothing).
+
+## Context
+
+- `AppleMusicAPI.getRecentlyPlayed()` (`shared/src/commonMain/.../network/AppleMusicAPI.kt`)
+  calls `GET /v1/me/recent/played/tracks` and maps to `List<MusicEntry>`.
+  **Critical Apple behavior:** the endpoint returns a *recency-ordered, de-duplicated*
+  list of tracks with **no play timestamps**. A re-listen moves the track to the head.
+  Diffing must therefore be **order-based against a persisted cursor**, not
+  timestamp-based.
+- `MusicEntry.id` is index-prefixed by the mapper (`"${index}_$id"`); the stable track
+  identifier is **`MusicEntry.entryId`** — cursors must use `entryId`.
+- `MusicEntry.duration` is in **seconds** (mapped from Apple's `durationInMillis`).
+- `LastFMClient.listLatestTracks(user)` returns `List<Track>` (name, artist, album,
+  `date: Instant`). `LastFMClient.scrobble(items: List<Scrobble>)` batch-scrobbles;
+  `Scrobble` carries track/artist/timestamp/album/albumArtist.
+- Per-user state comes from TASK_4's `UserStore` (`syncCursor` =
+  `lastSyncedHeadEntryId`, sync-run log). If TASK_4 is not merged yet, define a
+  minimal `SyncStateRepository` interface here and let TASK_6 bind it to `UserStore`.
+- Existing mobile scrobbling (`shared/.../domain/Scrobbler.kt`) scrobbles at
+  `Clock.System.now()` — the server may double-report plays the app already scrobbled;
+  hence the Last.fm cross-check below.
+
+## Requirements
+
+1. **`SyncEngine`** — a pure, constructor-injected class (location: `:server` main
+   source set, or `:shared` jvmMain if reuse is expected; prefer `:server` for
+   testability with Mokkery/fakes):
+   `SyncEngine(appleMusicAPI, lastFMClient, stateRepository, clock)` with a single
+   entry point `suspend fun sync(userId: String): SyncResult`.
+2. **Diff algorithm (order-based cursor):**
+   - Fetch the Apple recent list (newest first).
+   - New plays = entries from the head **until** the entry whose `entryId` equals the
+     persisted `lastSyncedHeadEntryId` (exclusive).
+   - A re-listen of an already-synced song appears before the old head and is therefore
+     detected (satisfies the "Song A again" step of the scenario).
+3. **Double-scrobble guard:** before scrobbling, fetch `listLatestTracks()` and drop any
+   candidate whose (artist, title) — case-insensitive — already appears in Last.fm
+   history within a recent window (default: since the last successful sync time, falling
+   back to the last N=50 scrobbles on first run). This protects against plays the mobile
+   apps already scrobbled in real time.
+4. **Scrobbling:** submit the remaining candidates in **chronological order** (reverse
+   of Apple's list) via one batch `scrobble()` call. Apple provides no timestamps, so
+   synthesize them backwards from `clock.now()`: the newest candidate gets `now`, each
+   previous one gets the next one's timestamp minus that track's duration (fallback 3
+   minutes when duration is 0). Timestamps must be strictly increasing in the submitted
+   batch and never in the future.
+5. **Cursor update:** persist the new head `entryId` **only after** the scrobble batch
+   succeeds (or when there was nothing to scrobble). A failed scrobble leaves the cursor
+   untouched so the next run retries.
+6. **Edge cases (all spec'd behavior, all tested):**
+   - *First run (no cursor):* initialize the cursor to the current head **without
+     scrobbling** (history before registration is not replayed).
+   - *Cursor not found in the fetched page* (more plays than the page size since last
+     run): treat the entire page as new plays.
+   - *Empty Apple list* or *empty diff:* no-op, still records a sync-run log entry.
+   - *Known limitation (document in KDoc + README if not already):* an immediate repeat
+     of the current head track between two runs does not change the list head and is
+     undetectable — the play is lost. Accepted.
+7. **`SyncResult`** value type: counts (candidates, dropped-by-guard, scrobbled), new
+   cursor, error info — consumed by TASK_6 for the sync-run log and `/api/users/status`.
+8. **Tests** (Mokkery mocks or hand-rolled fakes for `AppleMusicAPI`, `LastFMClient`,
+   repository; virtual clock):
+   - The **full canonical scenario** from README as a sequence of `sync()` calls:
+     A,B → scrobbles [A,B]; +C → [C]; +A → [A]; unchanged → [].
+   - First-run initialization; cursor-missing-from-page; guard drops an app-scrobbled
+     track; scrobble failure leaves cursor untouched; timestamp synthesis ordering.
+
+## Non-goals
+
+- No scheduling/looping over users (TASK_6).
+- No HTTP surface changes (no `openapi.yaml` update needed).
+- No token refresh handling beyond surfacing errors in `SyncResult` (TASK_6 maps 401/403
+  to `tokenStale`).
+
+## Validation
+
+```bash
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
+./gradlew ktlintCheck
+./gradlew :server:test        # or :shared:jvmTest if the engine lands in shared
+./gradlew :composeApp:assembleDebug
+```
+
+Delete `spec/PROGRESS.md`, then open a PR to `feature/kotlin_server`.

--- a/spec/TASK_5_SPEC.md
+++ b/spec/TASK_5_SPEC.md
@@ -91,4 +91,4 @@ export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
 ./gradlew :composeApp:assembleDebug
 ```
 
-Delete `spec/PROGRESS.md`, then open a PR to `feature/kotlin_server`.
+Delete `spec/PROGRESS.md`, then open a PR to `feature/kotlin-server/base`.

--- a/spec/TASK_6_SPEC.md
+++ b/spec/TASK_6_SPEC.md
@@ -13,13 +13,20 @@ for each, with per-user failure isolation and operational visibility.
 - `SYNC_INTERVAL_MINUTES` env config exists since TASK_3 (default 5).
 - `UserStore` (TASK_4) lists users and holds per-user tokens, session, cursor,
   `tokenStale`, and the sync-run log. `SyncResult` comes from TASK_5.
-- Per-user clients: for each user the loop builds an `AppleMusicAPI` (JVM
-  `MusicUserTokenProvider` injected with that user's Music-User-Token, developer token
-  from Arkana + `JWTTokenSigner` — TASK_1) and a `LastFMClient` restored from the
-  user's stored `Session` (TASK_2, with the per-user `Settings` isolation chosen
-  there).
-- `HTTPException` types exist in both `shared` (`network/model/HTTPException.kt`, carries
-  the status code) and `lastfmapi` — use them to classify failures.
+- Per-user clients: for each user the loop builds a `Configuration` via the public
+  per-user constructor from TASK_1 (JVM `MusicUserTokenProvider` instance injected with
+  that user's Music-User-Token — one instance per user, never a singleton; developer
+  token from Arkana + `JWTTokenSigner`) and a `LastFMClient` restored from the user's
+  stored `Session` (TASK_2, with the per-user `Settings` isolation chosen there), then
+  hands both to `SyncEngine` (`:shared` jvmMain, TASK_5).
+- Failure classification: `shared`'s `HTTPException` exposes `val code: Int` **after
+  TASK_1** (before it, the code is discarded); `lastfmapi`'s `HTTPException` exposes
+  `val code: HttpStatusCode`, and TASK_2 fixes `LastFMClient.scrobble`'s catch-all that
+  used to flatten everything to 500. Classify Apple-side vs Last.fm-side failures with
+  these.
+- **Cancellation caveat:** the shared HTTP layer historically wrapped
+  `CancellationException` into `HTTPException` (fixed in TASK_1/TASK_2) — the loop must
+  still be defensive: rethrow `CancellationException` before generic handling.
 
 ## Requirements
 
@@ -34,7 +41,13 @@ for each, with per-user failure isolation and operational visibility.
    - Build the per-user clients, call `SyncEngine.sync(user)`, append the `SyncResult`
      to the user's sync-run log and `lastSync` field.
    - **Isolation:** any exception is caught, logged (tagged with the user id — never the
-     raw token), recorded in the user's log, and the loop continues with the next user.
+     raw token), recorded in the user's log, and the loop continues with the next user —
+     **except `CancellationException`, which is rethrown** (also check
+     `coroutineContext.isActive` between users) so shutdown is not mistaken for a
+     per-user failure.
+   - **Store writes are field-level** (TASK_4 update semantics): the loop only touches
+     `syncCursor`/`lastSync`/`syncLog`/`tokenStale`, never whole documents, so it cannot
+     clobber a concurrent token push from the API.
 3. **Stale-token detection:** an Apple Music 401/403 marks the user's `tokenStale = true`
    in `UserStore`; the user is skipped until an app pushes a fresh token
    (`PUT /api/users/tokens/apple-music` clears the flag — TASK_4 behavior). Surfaced by

--- a/spec/TASK_6_SPEC.md
+++ b/spec/TASK_6_SPEC.md
@@ -1,0 +1,70 @@
+# TASK_6 — Scheduler loop + wiring + resilience
+
+Branch: `task/6-scheduler` · Depends on: TASK_4, TASK_5 · Protocol: [AGENT.md](AGENT.md)
+
+## Goal
+
+Turn the pieces into the running product: a cron-style coroutine loop that, on a
+configurable interval, iterates **all registered users** and runs `SyncEngine.sync(user)`
+for each, with per-user failure isolation and operational visibility.
+
+## Context
+
+- `SYNC_INTERVAL_MINUTES` env config exists since TASK_3 (default 5).
+- `UserStore` (TASK_4) lists users and holds per-user tokens, session, cursor,
+  `tokenStale`, and the sync-run log. `SyncResult` comes from TASK_5.
+- Per-user clients: for each user the loop builds an `AppleMusicAPI` (JVM
+  `MusicUserTokenProvider` injected with that user's Music-User-Token, developer token
+  from Arkana + `JWTTokenSigner` — TASK_1) and a `LastFMClient` restored from the
+  user's stored `Session` (TASK_2, with the per-user `Settings` isolation chosen
+  there).
+- `HTTPException` types exist in both `shared` (`network/model/HTTPException.kt`, carries
+  the status code) and `lastfmapi` — use them to classify failures.
+
+## Requirements
+
+1. **Scheduler:** a coroutine loop started with the Ktor application (and cancelled on
+   shutdown — hook `ApplicationStopping` / structured `CoroutineScope` tied to the
+   server lifecycle). Interval from `SYNC_INTERVAL_MINUTES`. Runs are strictly
+   sequential per instance (no overlapping ticks: if a run outlives the interval, the
+   next tick waits or is skipped — pick one, log it).
+2. **Per-user run:** each tick lists users from `UserStore` and for each user:
+   - Skip with a log line when preconditions are missing (`tokenStale == true`, no
+     Last.fm session yet) — never throws.
+   - Build the per-user clients, call `SyncEngine.sync(user)`, append the `SyncResult`
+     to the user's sync-run log and `lastSync` field.
+   - **Isolation:** any exception is caught, logged (tagged with the user id — never the
+     raw token), recorded in the user's log, and the loop continues with the next user.
+3. **Stale-token detection:** an Apple Music 401/403 marks the user's `tokenStale = true`
+   in `UserStore`; the user is skipped until an app pushes a fresh token
+   (`PUT /api/users/tokens/apple-music` clears the flag — TASK_4 behavior). Surfaced by
+   `GET /api/users/status` so the apps can prompt the user.
+4. **Observability:** structured log lines per tick (users processed / scrobbled /
+   skipped / failed) and per user; `/health` may optionally expose the last tick time.
+   If any HTTP surface changes, update `server/openapi.yaml` (mandate).
+5. **Graceful shutdown:** in-flight user sync finishes or cancels cleanly; no orphaned
+   coroutines (verify via test scope).
+6. **Tests:** virtual-time (`kotlinx-coroutines-test`) loop tests with a fake
+   `UserStore` + fake engine: multiple users where one fails and others still sync;
+   stale-token marking on 401; interval pacing; shutdown cancellation. A compose-level
+   smoke run proves end-to-end wiring (with fake tokens it logs a failed/skipped sync
+   rather than crashing).
+
+## Non-goals
+
+- No new app-facing endpoints (unless `/health` is extended — then update
+  `openapi.yaml`).
+- No retry/backoff sophistication beyond "next tick retries" — keep it simple.
+- No client-side work (TASK_7/8/9).
+
+## Validation
+
+```bash
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
+./gradlew ktlintCheck
+./gradlew :server:test
+docker compose build
+docker compose up -d && sleep 5 && docker compose logs server | grep -i "sync tick" && docker compose down
+```
+
+Delete `spec/PROGRESS.md`, then open a PR to `feature/kotlin_server`.

--- a/spec/TASK_6_SPEC.md
+++ b/spec/TASK_6_SPEC.md
@@ -67,4 +67,4 @@ docker compose build
 docker compose up -d && sleep 5 && docker compose logs server | grep -i "sync tick" && docker compose down
 ```
 
-Delete `spec/PROGRESS.md`, then open a PR to `feature/kotlin_server`.
+Delete `spec/PROGRESS.md`, then open a PR to `feature/kotlin-server/base`.

--- a/spec/TASK_7_SPEC.md
+++ b/spec/TASK_7_SPEC.md
@@ -76,4 +76,4 @@ export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
 
 Optional end-to-end check: `docker compose up` the server and run `pushTokens()` from a
 JVM test against `localhost` with a test secret. Delete `spec/PROGRESS.md`, then open a
-PR to `feature/kotlin_server`.
+PR to `feature/kotlin-server/base`.

--- a/spec/TASK_7_SPEC.md
+++ b/spec/TASK_7_SPEC.md
@@ -1,0 +1,79 @@
+# TASK_7 — Shared push use case (`ServerSyncUseCase`)
+
+Branch: `task/7-server-sync-usecase` · Depends on: TASK_2, TASK_4 · Protocol: [AGENT.md](AGENT.md)
+
+## Goal
+
+A shared (commonMain) use case both apps call to push the device-minted credentials to
+the server: the Apple Music **Music-User-Token** and the exported Last.fm **Session**.
+This is the only piece of client networking against the server API.
+
+## Context
+
+- Server contract: `server/openapi.yaml` (TASK_4) —
+  `PUT /api/users/tokens/apple-music`, `PUT /api/users/tokens/lastfm-session`,
+  `GET /api/users/status`; bearer shared-secret auth + `Music-User-Token` header.
+  **The OpenAPI document is authoritative** — read it before implementing.
+- Existing pieces to reuse:
+  - `UserTokenProvider.getUserToken(developerToken)` and
+    `Configuration`/`DeveloperToken` + `TokenSigner` for minting/obtaining the
+    Music-User-Token on device
+    (`shared/src/commonMain/.../domain/UserTokenProvider.kt`, `model/Configuration.kt`).
+  - `LastFMClient` session export from TASK_2 (via the `Scrobbler`/`LastFMUseCase`
+    layer — expose the current session through `Scrobbler` rather than constructing a
+    second `LastFMClient`).
+  - `IURLSession`/`URLSession` (`shared/src/commonMain/.../network/URLSession.kt`) for
+    HTTP — extend if it lacks request bodies (it currently only performs body-less
+    requests), or add a small dedicated Ktor client; prefer extending `IURLSession` so
+    tests can fake it like the rest of the codebase.
+  - `UseCase`/`ResultUseCase` base classes and the existing use-case patterns in
+    `shared/src/commonMain/.../domain/use_cases/`.
+  - `multiplatform-settings` (already a commonMain dependency) for persisting
+    configuration.
+- Consumers: TASK_8 (Android ViewModel) and TASK_9 (iOS SwiftUI) — the API surface must
+  be Swift-friendly (`@NativeCoroutinesState`/`@Throws` conventions as used in
+  `LastFMUseCase`).
+
+## Requirements
+
+1. **Configuration storage:** server base URL + shared secret persisted via
+   multiplatform-settings (secret ideally in secure storage where available — KVault is
+   already an androidMain dependency; keep the common interface simple:
+   `ServerConfigurationStore` with get/set/clear).
+2. **`ServerSyncUseCase`** (commonMain), constructor-injected dependencies, exposing:
+   - `suspend fun pushTokens()`: obtains the Music-User-Token via the existing
+     `UserTokenProvider` (may trigger the on-device MusicKit auth flow on first use),
+     PUTs it to `/api/users/tokens/apple-music`; then, if a Last.fm session exists
+     (TASK_2 export), PUTs it to `/api/users/tokens/lastfm-session`. Partial success is
+     reported distinctly (token pushed, session missing).
+   - `suspend fun fetchStatus()`: calls `GET /api/users/status` and maps to a small
+     model (registered, hasLastFmSession, tokenStale, lastSync).
+   - Observable state for UI (`StateFlow` + `@NativeCoroutinesState`, mirroring
+     `LastFMUseCase.isAuthenticated`): idle / syncing / success / error(message).
+3. **Headers:** `Authorization: Bearer <secret>` + `Music-User-Token` per the OpenAPI
+   contract; if TASK_4 implemented `previousTokenHash` migration, compute and send it
+   (persist the last-pushed token hash in settings).
+4. **Errors:** network/HTTP failures surface as state (and `@Throws`-compatible
+   exceptions for iOS), never crash; secrets never logged.
+5. **Tests** (commonTest, Mokkery + faked `IURLSession`): happy path (both PUTs, correct
+   headers/bodies), token-only partial push, 401 (bad secret) and 404 (unregistered
+   status) mapping, state transitions.
+
+## Non-goals
+
+- No UI (TASK_8/9).
+- No server changes; if the contract is wrong, fix it via a TASK_4 follow-up, not here.
+
+## Validation
+
+```bash
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
+./gradlew ktlintCheck
+./gradlew :shared:testAndroidHostTest :shared:jvmTest
+./gradlew iosSimulatorArm64Test
+./gradlew :composeApp:assembleDebug
+```
+
+Optional end-to-end check: `docker compose up` the server and run `pushTokens()` from a
+JVM test against `localhost` with a test secret. Delete `spec/PROGRESS.md`, then open a
+PR to `feature/kotlin_server`.

--- a/spec/TASK_7_SPEC.md
+++ b/spec/TASK_7_SPEC.md
@@ -1,6 +1,6 @@
 # TASK_7 — Shared push use case (`ServerSyncUseCase`)
 
-Branch: `task/7-server-sync-usecase` · Depends on: TASK_2, TASK_4 · Protocol: [AGENT.md](AGENT.md)
+Branch: `task/7-server-sync-usecase` · Depends on: TASK_1, TASK_2, TASK_4 · Protocol: [AGENT.md](AGENT.md)
 
 ## Goal
 

--- a/spec/TASK_8_SPEC.md
+++ b/spec/TASK_8_SPEC.md
@@ -54,4 +54,4 @@ export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
 Manual check: run `composeApp` against a locally running server (`docker compose up`),
 configure URL + secret, push tokens, confirm the user appears via
 `GET /api/users/status`. Delete `spec/PROGRESS.md`, then open a PR to
-`feature/kotlin_server`.
+`feature/kotlin-server/base`.

--- a/spec/TASK_8_SPEC.md
+++ b/spec/TASK_8_SPEC.md
@@ -1,0 +1,57 @@
+# TASK_8 — Android app integration
+
+Branch: `task/8-android-integration` · Depends on: TASK_7 · Protocol: [AGENT.md](AGENT.md)
+
+## Goal
+
+Let the Android app configure the sync server and push the user's tokens to it: a
+settings surface in `composeApp` wired to `ServerSyncUseCase`.
+
+## Context
+
+- `composeApp` is MVVM: one ViewModel per feature (player, history, playlist, lastfm)
+  constructed via `ViewModelFactory` — find them under
+  `composeApp/src/**/dev/igorcferreira/musicstreamsync/` and follow the existing
+  screen/ViewModel/navigation patterns exactly (study the Last.fm login screen, which is
+  the closest analog: form + async action + state display).
+- `ServerSyncUseCase` + `ServerConfigurationStore` (TASK_7) provide all logic and state;
+  this task is UI + wiring only.
+- The MusicKit auth flow may be triggered by `pushTokens()` on first use (the Android
+  `MusicUserTokenProvider` launches an activity result) — the action must be triggered
+  from a foreground Activity context, like existing flows.
+
+## Requirements
+
+1. **Server settings screen** (or section within the existing settings/Last.fm area,
+   matching current navigation): fields for server URL and shared secret (masked),
+   persisted through `ServerConfigurationStore`; a "Sync tokens to server" button; a
+   status area rendering the use case's state flow (idle/syncing/success/error) and the
+   result of `fetchStatus()` (registered, Last.fm session present, token stale warning).
+2. **ViewModel** (`ServerSyncViewModel` or matching naming), created via
+   `ViewModelFactory` like its peers, delegating to `ServerSyncUseCase` — no business
+   logic in the composables.
+3. **Token-stale handling:** when status reports `tokenStale`, show a prompt to re-sync
+   (the push clears the flag server-side).
+4. **Tests:** ViewModel unit test with a mocked use case (state propagation, action
+   dispatch). UI tests optional, matching whatever pattern already exists in
+   `composeApp`.
+
+## Non-goals
+
+- No iOS work (TASK_9).
+- No changes to `:shared` beyond what TASK_7 delivered (if the use case API is
+  insufficient, do a TASK_7 follow-up first).
+
+## Validation
+
+```bash
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
+./gradlew ktlintCheck
+./gradlew :composeApp:assembleDebug
+./gradlew :shared:testAndroidHostTest
+```
+
+Manual check: run `composeApp` against a locally running server (`docker compose up`),
+configure URL + secret, push tokens, confirm the user appears via
+`GET /api/users/status`. Delete `spec/PROGRESS.md`, then open a PR to
+`feature/kotlin_server`.

--- a/spec/TASK_9_SPEC.md
+++ b/spec/TASK_9_SPEC.md
@@ -56,4 +56,4 @@ swiftlint lint --config .swiftlint.yml
 Manual check: run in the simulator against a locally running server
 (`docker compose up`), configure URL + secret, push tokens, confirm via
 `GET /api/users/status`. Delete `spec/PROGRESS.md`, then open a PR to
-`feature/kotlin_server`.
+`feature/kotlin-server/base`.

--- a/spec/TASK_9_SPEC.md
+++ b/spec/TASK_9_SPEC.md
@@ -1,0 +1,59 @@
+# TASK_9 — iOS app integration
+
+Branch: `task/9-ios-integration` · Depends on: TASK_7 · Protocol: [AGENT.md](AGENT.md)
+
+## Goal
+
+Same capability as TASK_8, on iOS: a SwiftUI settings surface in `iosApp` that
+configures the sync server and pushes the user's tokens via the shared
+`ServerSyncUseCase` through the generated `MusicStream` framework.
+
+## Context
+
+- `iosApp/iosApp.xcodeproj` consumes the shared code as the `MusicStream` XCFramework
+  (`./gradlew :shared:assembleMusicStreamXCFramework`). Coroutine state is exposed to
+  Swift via KMP-NativeCoroutines (`@NativeCoroutinesState` — see how existing screens
+  observe `LastFMUseCase.isAuthenticated`).
+- `ServerSyncUseCase` (TASK_7) exposes `pushTokens()`, `fetchStatus()`, and an
+  observable state; `@Throws` functions surface as Swift `throws`.
+- On iOS the Music-User-Token comes from MusicKit via the `MusicKitBridge` Swift
+  package; the shared `UserTokenProvider` iOS actual already handles it —
+  `pushTokens()` may trigger the MusicKit permission prompt on first use.
+- Follow existing SwiftUI patterns in `iosApp` (view models/observable wrappers around
+  shared use cases, `App.xcconfig` for configuration) and SwiftLint
+  (`.swiftlint.yml`).
+
+## Requirements
+
+1. **Server settings view** (section in the existing settings/Last.fm area, matching the
+   app's navigation): server URL field, shared secret field (secure entry), "Sync tokens
+   to server" action, and a status area driven by the use case state + `fetchStatus()`
+   result (registered, Last.fm session present, token-stale warning with a re-sync
+   prompt).
+2. **Observation:** state consumed through the KMP-NativeCoroutines Swift APIs the
+   project already uses — no polling.
+3. **Errors:** failures render as user-visible messages (matching existing error
+   presentation), never crash; the secret is never printed/logged.
+4. **Framework surface:** if any shared API turns out not Swift-usable, fix it via a
+   TASK_7 follow-up (do not fork logic into Swift).
+
+## Non-goals
+
+- No Android work (TASK_8).
+- No new shared business logic.
+
+## Validation
+
+```bash
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
+./gradlew ktlintCheck
+./gradlew :shared:assembleMusicStreamXCFramework
+./gradlew iosSimulatorArm64Test
+swiftlint lint --config .swiftlint.yml
+# Build the app (per root CLAUDE.md): xcodebuild or xcrun MCP tooling on iosApp/iosApp.xcodeproj
+```
+
+Manual check: run in the simulator against a locally running server
+(`docker compose up`), configure URL + secret, push tokens, confirm via
+`GET /api/users/status`. Delete `spec/PROGRESS.md`, then open a PR to
+`feature/kotlin_server`.


### PR DESCRIPTION
## Plan approval: Kotlin sync server

A JVM server process built on the KMP shared code that runs a cron-style loop to sync Apple Music play history into Last.fm for multiple users. The native apps mint the Music-User-Token and Last.fm session on-device and push them to the server, since Apple provides no server-side login or token refresh.

This PR adds the spec-driven task breakdown for the feature (see `spec/README.md` for the architecture, decisions record, and task table). Merging it approves the plan; implementation then proceeds task-by-task on `task/<n>-<short-name>` branches targeting `feature/kotlin-server/base`, following `spec/AGENT.md`.

### Tasks

| ID | Title | Depends on |
| --- | --- | --- |
| 1 | `:shared` JVM target + actuals | — |
| 2 | lastfmapi session portability | — |
| 3 | `:server` scaffold + Docker environment | — |
| 4 | Multi-user token-sync API + persistence | 2, 3 |
| 5 | Sync engine (diff + scrobble) | 1, 2 |
| 6 | Scheduler loop + wiring | 4, 5 |
| 7 | Shared push use case (`ServerSyncUseCase`) | 2, 4 |
| 8 | Android app integration | 7 |
| 9 | iOS app integration | 7 |