### PR TITLE
spec: generate openapi.yaml from code (goal + TASK_10)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,94 +24,150 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Decide whether the PR touches anything that needs building/testing. Docs-only
+  # changes (Markdown, spec/, docs/) and CI/workflow-only changes (.github/) do not.
+  #
+  # swiftlint / ktlint / android-lint / tests are REQUIRED checks on `main`, so they
+  # must always report a status — a skipped *job* would leave the check pending and
+  # block the PR. They therefore always run (keeping their names), but do their real
+  # work only when code changed, and drop to a cheap runner otherwise. The net effect:
+  # a docs-only PR gets four green checks in seconds instead of a full build matrix.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Detect non-doc changes
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          files=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" \
+            --paginate --jq '.[].filename')
+          echo "Changed files:"
+          printf '%s\n' "$files"
+          # Paths that never need the build/test/lint matrix (docs, spec, CI config).
+          doc='(^spec/)|(^docs/)|(^\.github/)|(\.md$)|(^LICENSE$)'
+          non_doc=$(printf '%s\n' "$files" | grep -vE "$doc" || true)
+          if [ -n "$non_doc" ]; then code=true; else code=false; fi
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+          echo "Detected code=$code"
+
   swiftlint:
-    runs-on: macos-26
+    needs: changes
+    runs-on: ${{ needs.changes.outputs.code == 'true' && 'macos-26' || 'ubuntu-latest' }}
     steps:
       - name: Checkout repository
+        if: needs.changes.outputs.code == 'true'
         uses: actions/checkout@v6
       - name: Install SwiftLint
+        if: needs.changes.outputs.code == 'true'
         run: brew install swiftlint
       - name: Lint Swift
+        if: needs.changes.outputs.code == 'true'
         run: swiftlint lint --config .swiftlint.yml --reporter github-actions-logging
 
   ktlint:
-    runs-on: macos-26
+    needs: changes
+    runs-on: ${{ needs.changes.outputs.code == 'true' && 'macos-26' || 'ubuntu-latest' }}
     steps:
       - name: Checkout repository
+        if: needs.changes.outputs.code == 'true'
         uses: actions/checkout@v6
       - name: Cache Ruby gems
+        if: needs.changes.outputs.code == 'true'
         uses: actions/cache@v5
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('Gemfile.lock') }}
           restore-keys: ${{ runner.os }}-gems-
       - name: Generate Arkana module
+        if: needs.changes.outputs.code == 'true'
         run: |
           bundle config set --local path 'vendor/bundle'
           bundle install
           bundle exec arkana -l kotlin
       - uses: actions/setup-java@v5
+        if: needs.changes.outputs.code == 'true'
         with:
           distribution: 'temurin'
           java-version: '17'
           cache: gradle
       - name: Setup Gradle
+        if: needs.changes.outputs.code == 'true'
         uses: gradle/actions/setup-gradle@v5
       - name: Lint Kotlin
+        if: needs.changes.outputs.code == 'true'
         run: ./gradlew ktlintCheck
 
   android-lint:
-    runs-on: macos-26
+    needs: changes
+    runs-on: ${{ needs.changes.outputs.code == 'true' && 'macos-26' || 'ubuntu-latest' }}
     steps:
       - name: Checkout repository
+        if: needs.changes.outputs.code == 'true'
         uses: actions/checkout@v6
       - name: Cache Ruby gems
+        if: needs.changes.outputs.code == 'true'
         uses: actions/cache@v5
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('Gemfile.lock') }}
           restore-keys: ${{ runner.os }}-gems-
       - name: Generate Arkana module
+        if: needs.changes.outputs.code == 'true'
         run: |
           bundle config set --local path 'vendor/bundle'
           bundle install
           bundle exec arkana -l kotlin
       - uses: actions/setup-java@v5
+        if: needs.changes.outputs.code == 'true'
         with:
           distribution: 'temurin'
           java-version: '17'
           cache: gradle
       - name: Setup Gradle
+        if: needs.changes.outputs.code == 'true'
         uses: gradle/actions/setup-gradle@v5
       - name: Lint Android
+        if: needs.changes.outputs.code == 'true'
         run: ./gradlew lint
 
   tests:
-    runs-on: macos-26
+    needs: changes
+    runs-on: ${{ needs.changes.outputs.code == 'true' && 'macos-26' || 'ubuntu-latest' }}
     steps:
       - name: Checkout repository
+        if: needs.changes.outputs.code == 'true'
         uses: actions/checkout@v6
       - name: Cache Ruby gems
+        if: needs.changes.outputs.code == 'true'
         uses: actions/cache@v5
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('Gemfile.lock') }}
           restore-keys: ${{ runner.os }}-gems-
       - name: Generate Arkana module
+        if: needs.changes.outputs.code == 'true'
         run: |
           bundle config set --local path 'vendor/bundle'
           bundle install
           bundle exec arkana -l kotlin
       - uses: actions/setup-java@v5
+        if: needs.changes.outputs.code == 'true'
         with:
           distribution: 'temurin'
           java-version: '17'
           cache: gradle
       - name: Setup Gradle
+        if: needs.changes.outputs.code == 'true'
         uses: gradle/actions/setup-gradle@v5
       - name: Run tests
+        if: needs.changes.outputs.code == 'true'
         run: ./gradlew testAndroid iosSimulatorArm64Test :lastfmapi:jvmTest :server:test
       - name: Publish Test Report
+        if: needs.changes.outputs.code == 'true'
         uses: actions/upload-artifact@v6
         with:
           name: test-results
@@ -120,8 +176,8 @@ jobs:
             ./lastfmapi/build/test-results
             ./server/build/test-results
       - name: Annotate Test Report
+        if: needs.changes.outputs.code == 'true' && (success() || failure())
         uses: mikepenz/action-junit-report@v6
-        if: success() || failure()
         with:
           report_paths: '**/build/test-results/**/TEST-*.xml'
           comment: 'true'

--- a/spec/AGENT.md
+++ b/spec/AGENT.md
@@ -49,13 +49,21 @@ is **branch-local scratch state**:
 ## API documentation mandate (Swagger/OpenAPI)
 
 Every HTTP API created for consumption by the native apps MUST be documented in the
-single Swagger document **`server/openapi.yaml`** (created by TASK_3, served by the
-server at `GET /openapi.yaml`).
+single Swagger document **`server/openapi.yaml`**, served by the server at
+`GET /openapi.yaml`.
 
-- Any task that adds or changes an endpoint updates `server/openapi.yaml` **in the same
-  task**.
-- A task touching the HTTP surface is not `done` until the document matches the
-  implemented API (paths, schemas, auth scheme, error responses).
+**Target end-state (TASK_10): the document is _generated from the code's route
+definitions_**, so the code is the single source of truth. The documentation
+(summaries, schemas, examples, error responses, security) lives on the routes, and the
+checked-in `server/openapi.yaml` is a generated snapshot that CI verifies stays in sync.
+The generated document must be as complete as possible — every operation described, with
+examples.
+
+- Any task that adds or changes an endpoint documents it **in the same task** — on the
+  route (once TASK_10 has landed) or, until then, by hand-editing `server/openapi.yaml`.
+- A task touching the HTTP surface is not `done` until the served document matches the
+  implemented API (paths, schemas, auth scheme, error responses) and — after TASK_10 —
+  the checked-in snapshot has been regenerated.
 
 ## Docker mandate
 

--- a/spec/AGENT.md
+++ b/spec/AGENT.md
@@ -60,7 +60,8 @@ The generated document must be as complete as possible — every operation descr
 examples.
 
 - Any task that adds or changes an endpoint documents it **in the same task** — on the
-  route (once TASK_10 has landed) or, until then, by hand-editing `server/openapi.yaml`.
+  route, using the TASK_10 generation setup (which lands before the token API). TASK_3's
+  initial document predates TASK_10 and is hand-written; TASK_10 migrates it.
 - A task touching the HTTP surface is not `done` until the served document matches the
   implemented API (paths, schemas, auth scheme, error responses) and — after TASK_10 —
   the checked-in snapshot has been regenerated.

--- a/spec/README.md
+++ b/spec/README.md
@@ -63,7 +63,7 @@ key) to the server.
 | Last.fm auth | **Apps push the session key** (apps authenticate on-device via `LastFMClient`, export the `Session`, upload it). No Last.fm credentials on the server. |
 | Persistence | **MongoDB** (docker-compose service, official Kotlin coroutine driver): per-user token, session, sync cursor, sync-run log. |
 | Environment | **Docker mandate**: dev and deploy via `Dockerfile` + `docker-compose.yml` (server + mongodb). |
-| API docs | **Swagger mandate**: single `server/openapi.yaml`, updated in the same task as any endpoint change. |
+| API docs | **OpenAPI generation mandate**: a single `server/openapi.yaml` served at `GET /openapi.yaml`, **generated from the code's route definitions** (code is the source of truth; summaries, schemas, and examples live on the routes) with a CI drift check on the checked-in snapshot. Realized by TASK_10; until then, tasks hand-edit the file in the same task as any endpoint change. |
 | Branching | `feature/kotlin-server/base` is the integration branch; each task works on `task/<n>-<short-name>` and merges via PR. |
 
 ## Pre-PR review mandate
@@ -98,6 +98,7 @@ Status values: `pending` / `in_progress` / `in_review` (PR open) / `done` (PR me
 | 7 | Shared push use case (`ServerSyncUseCase`) | 1, 2, 4 | pending | — | — | [TASK_7_SPEC.md](TASK_7_SPEC.md) |
 | 8 | Android app integration | 7 | pending | — | — | [TASK_8_SPEC.md](TASK_8_SPEC.md) |
 | 9 | iOS app integration | 7 | pending | — | — | [TASK_9_SPEC.md](TASK_9_SPEC.md) |
+| 10 | Generate `openapi.yaml` from code | 3, 4 | pending | — | — | [TASK_10_SPEC.md](TASK_10_SPEC.md) |
 
 ### Dependency graph / parallelism
 
@@ -112,7 +113,8 @@ TASK_3 ──┴► TASK_4 ─┴─────────────┘
 
 - Wave 1 (parallel): TASK_1 ∥ TASK_2 ∥ TASK_3
 - Wave 2 (parallel): TASK_4 (needs 2+3) ∥ TASK_5 (needs 1+2)
-- Wave 3: TASK_6 (needs 4+5) ∥ TASK_7 (needs 1+2+4)
+- Wave 3: TASK_6 (needs 4+5) ∥ TASK_7 (needs 1+2+4) ∥ TASK_10 (needs 3+4 — generate
+  `openapi.yaml` from code once the full HTTP surface exists)
 - Wave 4 (parallel): TASK_8 ∥ TASK_9 (need 7)
 
 ## Session log
@@ -127,3 +129,4 @@ TASK_3 ──┴► TASK_4 ─┴─────────────┘
 - 2026-07-10 — protocol — added the pre-PR senior-Kotlin-developer sub-agent review mandate to this README; ran it on TASK_2 and applied the findings (restoreSession scoping docs, thread-safe InMemorySettings, blank-key fail-fast, evidence-grade now-playing fixture) on the PR #83 branch.
 - 2026-07-10 — TASK_2 — merged → done; also added the atomic-commit mandate to this README.
 - 2026-07-10 — TASK_3 — `task/3-server-scaffold` — scaffolded the `:server` Ktor/JVM module (env `ServerConfig`, MongoDB coroutine client, DI `DatabasePinger`, `GET /health`), the single `server/openapi.yaml` served at `GET /openapi.yaml`, `:server:test` suites, and the Docker environment (multi-stage JDK21 build + JRE21 runtime, `docker-compose.yml`); `docker compose up` smoke passed. Extended CI (`test.yml`) to run the lastfmapi + server JVM tests. Rebased onto merged base; atomic commits; PR opened.
+- 2026-07-10 — spec — added the OpenAPI-generation goal: `server/openapi.yaml` will be generated from the code's route definitions (new TASK_10, needs 3+4), reworked the API-docs mandate (AGENT.md) and the decisions record accordingly.

--- a/spec/README.md
+++ b/spec/README.md
@@ -63,7 +63,7 @@ key) to the server.
 | Last.fm auth | **Apps push the session key** (apps authenticate on-device via `LastFMClient`, export the `Session`, upload it). No Last.fm credentials on the server. |
 | Persistence | **MongoDB** (docker-compose service, official Kotlin coroutine driver): per-user token, session, sync cursor, sync-run log. |
 | Environment | **Docker mandate**: dev and deploy via `Dockerfile` + `docker-compose.yml` (server + mongodb). |
-| API docs | **OpenAPI generation mandate**: a single `server/openapi.yaml` served at `GET /openapi.yaml`, **generated from the code's route definitions** (code is the source of truth; summaries, schemas, and examples live on the routes) with a CI drift check on the checked-in snapshot. Realized by TASK_10; until then, tasks hand-edit the file in the same task as any endpoint change. |
+| API docs | **OpenAPI generation mandate**: a single `server/openapi.yaml` served at `GET /openapi.yaml`, **generated from the code's route definitions** (code is the source of truth; summaries, schemas, and examples live on the routes) with a CI drift check on the checked-in snapshot. Established by TASK_10 **before** the token API (TASK_4), so endpoints are documented in-code from TASK_4 on; TASK_3's initial document is hand-written and TASK_10 migrates it to generation. |
 | Branching | `feature/kotlin-server/base` is the integration branch; each task works on `task/<n>-<short-name>` and merges via PR. |
 
 ## Pre-PR review mandate
@@ -92,30 +92,35 @@ Status values: `pending` / `in_progress` / `in_review` (PR open) / `done` (PR me
 | 1 | `:shared` JVM target + actuals | — | done | `task/1-shared-jvm-target` | [#82](https://github.com/igorcferreira/MusicStreamSync/pull/82) | [TASK_1_SPEC.md](TASK_1_SPEC.md) |
 | 2 | lastfmapi session portability | — | done | `task/2-lastfm-session-portability` | [#83](https://github.com/igorcferreira/MusicStreamSync/pull/83) | [TASK_2_SPEC.md](TASK_2_SPEC.md) |
 | 3 | `:server` scaffold + Docker environment | — | in_review | `task/3-server-scaffold` | [#84](https://github.com/igorcferreira/MusicStreamSync/pull/84) | [TASK_3_SPEC.md](TASK_3_SPEC.md) |
-| 4 | Multi-user token-sync API + persistence | 2, 3 | pending | — | — | [TASK_4_SPEC.md](TASK_4_SPEC.md) |
+| 4 | Multi-user token-sync API + persistence | 2, 3, 10 | pending | — | — | [TASK_4_SPEC.md](TASK_4_SPEC.md) |
 | 5 | Sync engine (diff + scrobble) | 1, 2 | pending | — | — | [TASK_5_SPEC.md](TASK_5_SPEC.md) |
 | 6 | Scheduler loop + wiring | 4, 5 | pending | — | — | [TASK_6_SPEC.md](TASK_6_SPEC.md) |
 | 7 | Shared push use case (`ServerSyncUseCase`) | 1, 2, 4 | pending | — | — | [TASK_7_SPEC.md](TASK_7_SPEC.md) |
 | 8 | Android app integration | 7 | pending | — | — | [TASK_8_SPEC.md](TASK_8_SPEC.md) |
 | 9 | iOS app integration | 7 | pending | — | — | [TASK_9_SPEC.md](TASK_9_SPEC.md) |
-| 10 | Generate `openapi.yaml` from code | 3, 4 | pending | — | — | [TASK_10_SPEC.md](TASK_10_SPEC.md) |
+| 10 | Generate `openapi.yaml` from code | 3 | pending | — | — | [TASK_10_SPEC.md](TASK_10_SPEC.md) |
 
 ### Dependency graph / parallelism
 
 ```
-TASK_1 ──┬──────────┬──► TASK_5 ──┐
-TASK_2 ──┼──────────┤             ├──► TASK_6
-         │          │             │
-TASK_3 ──┴► TASK_4 ─┴─────────────┘
-                └─────► TASK_7 ──► TASK_8
-         (also needs 1, 2)      └► TASK_9
+TASK_1 ──┬─────────────────────► TASK_5 ──┐
+TASK_2 ──┤                                 ├──► TASK_6
+         │                                 │
+TASK_3 ──┴► TASK_10 ──► TASK_4 ────────────┴──► TASK_7 ──┬──► TASK_8
+                                                         └──► TASK_9
 ```
 
+Edges show the critical path; TASK_4 also needs 2, TASK_7 also needs 1+2 (the
+`Depends on` column is authoritative). TASK_10 establishes OpenAPI generation from the
+`/health` surface before TASK_4 adds the token API, so the token endpoints are
+documented in-code from the start.
+
 - Wave 1 (parallel): TASK_1 ∥ TASK_2 ∥ TASK_3
-- Wave 2 (parallel): TASK_4 (needs 2+3) ∥ TASK_5 (needs 1+2)
-- Wave 3: TASK_6 (needs 4+5) ∥ TASK_7 (needs 1+2+4) ∥ TASK_10 (needs 3+4 — generate
-  `openapi.yaml` from code once the full HTTP surface exists)
-- Wave 4 (parallel): TASK_8 ∥ TASK_9 (need 7)
+- Wave 2 (parallel): TASK_5 (needs 1+2) ∥ TASK_10 (needs 3 — establish OpenAPI
+  generation from `/health`)
+- Wave 3: TASK_4 (needs 2+3+10 — token API, documented in-code via the generation setup)
+- Wave 4 (parallel): TASK_6 (needs 4+5) ∥ TASK_7 (needs 1+2+4)
+- Wave 5 (parallel): TASK_8 ∥ TASK_9 (need 7)
 
 ## Session log
 
@@ -129,4 +134,5 @@ TASK_3 ──┴► TASK_4 ─┴─────────────┘
 - 2026-07-10 — protocol — added the pre-PR senior-Kotlin-developer sub-agent review mandate to this README; ran it on TASK_2 and applied the findings (restoreSession scoping docs, thread-safe InMemorySettings, blank-key fail-fast, evidence-grade now-playing fixture) on the PR #83 branch.
 - 2026-07-10 — TASK_2 — merged → done; also added the atomic-commit mandate to this README.
 - 2026-07-10 — TASK_3 — `task/3-server-scaffold` — scaffolded the `:server` Ktor/JVM module (env `ServerConfig`, MongoDB coroutine client, DI `DatabasePinger`, `GET /health`), the single `server/openapi.yaml` served at `GET /openapi.yaml`, `:server:test` suites, and the Docker environment (multi-stage JDK21 build + JRE21 runtime, `docker-compose.yml`); `docker compose up` smoke passed. Extended CI (`test.yml`) to run the lastfmapi + server JVM tests. Rebased onto merged base; atomic commits; PR opened.
-- 2026-07-10 — spec — added the OpenAPI-generation goal: `server/openapi.yaml` will be generated from the code's route definitions (new TASK_10, needs 3+4), reworked the API-docs mandate (AGENT.md) and the decisions record accordingly.
+- 2026-07-10 — spec — added the OpenAPI-generation goal: `server/openapi.yaml` will be generated from the code's route definitions (new TASK_10), reworked the API-docs mandate (AGENT.md) and the decisions record accordingly.
+- 2026-07-10 — spec — retargeted TASK_10 to run **before** TASK_4 (TASK_10 now needs only 3; TASK_4 gains a dependency on 10), so the token API is documented in-code from the start; updated the graph/waves and both task specs.

--- a/spec/TASK_10_SPEC.md
+++ b/spec/TASK_10_SPEC.md
@@ -1,0 +1,100 @@
+# TASK_10 — Generate `server/openapi.yaml` from the code
+
+Branch: `task/10-openapi-generation` · Depends on: TASK_3, TASK_4 · Protocol: [AGENT.md](AGENT.md)
+
+## Goal
+
+Make the code the **single source of truth** for the HTTP API documentation: the server's
+routes carry their own OpenAPI documentation (summaries, parameters, request/response
+schemas, examples, error responses, security), and `server/openapi.yaml` is **generated
+from those route definitions** rather than hand-maintained. The generated document must
+be as complete as possible — every operation fully described, with realistic examples —
+and the checked-in `server/openapi.yaml` is a generated snapshot that CI verifies stays
+in sync with the code.
+
+This realizes the API-docs mandate in [AGENT.md](AGENT.md): after this task, "documenting
+an endpoint" means annotating its route, and the Swagger document falls out automatically.
+
+## Context
+
+- TASK_3 created a **hand-written** `server/openapi.yaml`, packaged into the jar and
+  served at `GET /openapi.yaml` (`server/src/main/.../Application.kt` loads it from
+  resources). TASK_4 extended it by hand with the token API. This task replaces that
+  hand-maintenance with code-driven generation.
+- HTTP surface to document (the complete server API once TASK_4 is merged):
+  - `GET /health` — unauthenticated; `{ status, mongo }`; 200 with `mongo:false` when
+    MongoDB is unreachable (the documented degraded case).
+  - `GET /openapi.yaml` — the document itself (meta).
+  - `PUT /api/users/tokens/apple-music`, `PUT /api/users/tokens/lastfm-session`,
+    `GET /api/users/status` — bearer-secured (`Authorization: Bearer <SYNC_SHARED_SECRET>`)
+    plus the `Music-User-Token` header where TASK_4 requires it; request/response bodies
+    reuse the `Session` wire shape (`{ name, key, subscriber? }`, TASK_2) and the shared
+    error schema TASK_4 defines.
+- **Recommended library:** the Ktor route-DSL generator
+  [`io.github.smiley4:ktor-openapi`](https://github.com/SMILEY4/ktor-openapi-tools)
+  (+ `ktor-swagger-ui` for the optional UI), which attaches documentation to routes and
+  builds the schema from kotlinx-serialization types. Ktor's own `ktor-server-openapi`/
+  `ktor-server-swagger` only *serve* a static spec and do not generate from routes, so
+  they do not satisfy this goal. The library is a recommendation — if a better fit is
+  found, update this spec in the task branch, note it in the PR, then implement.
+- Add the chosen dependency to `gradle/libs.versions.toml` (new version + library
+  entries) alongside the existing `ktor` entries.
+
+## Requirements
+
+1. **Routes are documented in code.** Every endpoint declares its OpenAPI documentation
+   at the route (summary/description, tags, path/query/header parameters, request body
+   schema, each response status with schema, and the security requirement). Schemas come
+   from the existing kotlinx-serialization types (`HealthResponse`, `Session`, the token
+   request/response and error types), not re-declared by hand.
+2. **`server/openapi.yaml` is generated, not authored.** Provide a deterministic way to
+   emit the document to `server/openapi.yaml` (e.g. a `:server:generateOpenApi` Gradle
+   task or a test that writes it), documented in `server/README.md`. The served
+   `GET /openapi.yaml` returns the **generated** document (drop the hand-written resource
+   load); it stays valid OpenAPI 3.x and keeps the `application/yaml` content type.
+3. **Drift guard in CI.** A `:server:test` check (or Gradle verification task wired into
+   the build) regenerates the document and fails if it differs from the checked-in
+   `server/openapi.yaml`, with a message telling the developer to regenerate. This
+   preserves the "single checked-in document" mandate while keeping code authoritative.
+4. **Completeness bar** — the generated document must, for every operation, include:
+   - `summary` and `description`;
+   - all parameters/headers (incl. the bearer `Authorization` and `Music-User-Token`),
+     each with a description and, where useful, an example;
+   - request body schema **with at least one example** (where a body exists);
+   - **every** response status the route can return (200 plus 400/401/404 as applicable),
+     each with a schema and a realistic example (including the `/health` `mongo:false`
+     degraded example and the shared error example);
+   - the `securityScheme` (bearer `syncSharedSecret`) applied to `/api/*` and explicitly
+     opted out (`security: []`) on `/health` and `/openapi.yaml`;
+   - reusable component schemas (`Session`, error, health, token payloads) referenced via
+     `$ref`, not inlined per operation.
+5. **Optional Swagger UI.** Serving interactive docs (e.g. at `GET /swagger`) is a
+   nice-to-have; if added it must be unauthenticated and must not change the API.
+6. **Mandate reconciliation.** Update `server/README.md` (how to regenerate; that the
+   file is generated) and remove any now-stale "edit the yaml by hand" instructions from
+   the server docs. The AGENT.md mandate already points here.
+7. **Tests:** assert the generated document (a) is valid OpenAPI 3.x, (b) contains every
+   path with its documented responses/examples/security, and (c) matches the checked-in
+   snapshot (the drift guard). Keep the existing `/health` and `/openapi.yaml`
+   `testApplication` behavior tests green.
+
+## Non-goals
+
+- No new endpoints and **no behavior change** to existing ones — documentation only.
+- Not switching web frameworks; Ktor stays.
+- No client-generation / SDK output from the spec (possible follow-up task).
+
+## Validation
+
+```bash
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
+./gradlew ktlintCheck
+./gradlew :server:generateOpenApi   # (or the equivalent) — regenerates server/openapi.yaml
+./gradlew :server:test              # includes the drift guard + completeness assertions
+./gradlew :composeApp:assembleDebug # repo stays green
+docker compose build
+docker compose up -d --wait && curl -fsS localhost:8080/openapi.yaml && docker compose down
+```
+
+The served and checked-in documents must be identical and validate as OpenAPI 3.x.
+Delete `spec/PROGRESS.md`, then open a PR to `feature/kotlin-server/base`.

--- a/spec/TASK_10_SPEC.md
+++ b/spec/TASK_10_SPEC.md
@@ -1,6 +1,6 @@
 # TASK_10 — Generate `server/openapi.yaml` from the code
 
-Branch: `task/10-openapi-generation` · Depends on: TASK_3, TASK_4 · Protocol: [AGENT.md](AGENT.md)
+Branch: `task/10-openapi-generation` · Depends on: TASK_3 · Protocol: [AGENT.md](AGENT.md)
 
 ## Goal
 
@@ -12,6 +12,12 @@ be as complete as possible — every operation fully described, with realistic e
 and the checked-in `server/openapi.yaml` is a generated snapshot that CI verifies stays
 in sync with the code.
 
+This task runs **before** the token API (TASK_4) so that the generation infrastructure
+and the **completeness bar** below are in place first: TASK_4 (and every later endpoint
+task) documents its routes in code from the start, rather than hand-editing YAML that a
+later task migrates. TASK_10 itself documents the only surface that exists at TASK_3
+(`/health`, `/openapi.yaml`) and establishes the pattern.
+
 This realizes the API-docs mandate in [AGENT.md](AGENT.md): after this task, "documenting
 an endpoint" means annotating its route, and the Swagger document falls out automatically.
 
@@ -19,17 +25,17 @@ an endpoint" means annotating its route, and the Swagger document falls out auto
 
 - TASK_3 created a **hand-written** `server/openapi.yaml`, packaged into the jar and
   served at `GET /openapi.yaml` (`server/src/main/.../Application.kt` loads it from
-  resources). TASK_4 extended it by hand with the token API. This task replaces that
-  hand-maintenance with code-driven generation.
-- HTTP surface to document (the complete server API once TASK_4 is merged):
+  resources). This task replaces that hand-maintenance with code-driven generation.
+- HTTP surface to document at this point (the whole server API as of TASK_3):
   - `GET /health` — unauthenticated; `{ status, mongo }`; 200 with `mongo:false` when
     MongoDB is unreachable (the documented degraded case).
   - `GET /openapi.yaml` — the document itself (meta).
-  - `PUT /api/users/tokens/apple-music`, `PUT /api/users/tokens/lastfm-session`,
-    `GET /api/users/status` — bearer-secured (`Authorization: Bearer <SYNC_SHARED_SECRET>`)
-    plus the `Music-User-Token` header where TASK_4 requires it; request/response bodies
-    reuse the `Session` wire shape (`{ name, key, subscriber? }`, TASK_2) and the shared
-    error schema TASK_4 defines.
+  - The bearer `syncSharedSecret` security scheme already declared in the document must
+    be modelled in the generation setup so TASK_4's `/api/*` routes can apply it.
+- TASK_4 then adds the token API (`PUT /api/users/tokens/apple-music`,
+  `PUT /api/users/tokens/lastfm-session`, `GET /api/users/status`) and documents those
+  routes **in code**, on this infrastructure, meeting the same completeness bar — it does
+  not hand-edit `server/openapi.yaml`.
 - **Recommended library:** the Ktor route-DSL generator
   [`io.github.smiley4:ktor-openapi`](https://github.com/SMILEY4/ktor-openapi-tools)
   (+ `ktor-swagger-ui` for the optional UI), which attaches documentation to routes and
@@ -42,11 +48,12 @@ an endpoint" means annotating its route, and the Swagger document falls out auto
 
 ## Requirements
 
-1. **Routes are documented in code.** Every endpoint declares its OpenAPI documentation
-   at the route (summary/description, tags, path/query/header parameters, request body
-   schema, each response status with schema, and the security requirement). Schemas come
-   from the existing kotlinx-serialization types (`HealthResponse`, `Session`, the token
-   request/response and error types), not re-declared by hand.
+1. **Routes are documented in code.** Every endpoint that exists at TASK_3 declares its
+   OpenAPI documentation at the route (summary/description, tags, path/query/header
+   parameters, response status(es) with schema, and the security requirement). Schemas
+   come from the existing kotlinx-serialization types (`HealthResponse`), not re-declared
+   by hand. The setup must make it straightforward for TASK_4 to add request-body schemas,
+   header parameters, and reusable component schemas (`Session`, error) the same way.
 2. **`server/openapi.yaml` is generated, not authored.** Provide a deterministic way to
    emit the document to `server/openapi.yaml` (e.g. a `:server:generateOpenApi` Gradle
    task or a test that writes it), documented in `server/README.md`. The served
@@ -56,18 +63,21 @@ an endpoint" means annotating its route, and the Swagger document falls out auto
    the build) regenerates the document and fails if it differs from the checked-in
    `server/openapi.yaml`, with a message telling the developer to regenerate. This
    preserves the "single checked-in document" mandate while keeping code authoritative.
-4. **Completeness bar** — the generated document must, for every operation, include:
+4. **Completeness bar** — this is the standard the generated document must meet for
+   **every operation**, and the bar TASK_4's endpoints must also satisfy. Each operation
+   includes:
    - `summary` and `description`;
-   - all parameters/headers (incl. the bearer `Authorization` and `Music-User-Token`),
-     each with a description and, where useful, an example;
+   - all parameters/headers (incl., where applicable, the bearer `Authorization` and
+     `Music-User-Token`), each with a description and, where useful, an example;
    - request body schema **with at least one example** (where a body exists);
    - **every** response status the route can return (200 plus 400/401/404 as applicable),
      each with a schema and a realistic example (including the `/health` `mongo:false`
-     degraded example and the shared error example);
-   - the `securityScheme` (bearer `syncSharedSecret`) applied to `/api/*` and explicitly
-     opted out (`security: []`) on `/health` and `/openapi.yaml`;
-   - reusable component schemas (`Session`, error, health, token payloads) referenced via
-     `$ref`, not inlined per operation.
+     degraded example);
+   - the `securityScheme` (bearer `syncSharedSecret`) modelled and applied to secured
+     routes, with `/health` and `/openapi.yaml` explicitly opted out (`security: []`);
+   - reusable component schemas referenced via `$ref`, not inlined per operation.
+   At TASK_3's surface this covers `/health` and `/openapi.yaml`; TASK_4 extends the same
+   bar to the token payloads (`Session`, error) and `/api/*` security.
 5. **Optional Swagger UI.** Serving interactive docs (e.g. at `GET /swagger`) is a
    nice-to-have; if added it must be unauthenticated and must not change the API.
 6. **Mandate reconciliation.** Update `server/README.md` (how to regenerate; that the

--- a/spec/TASK_4_SPEC.md
+++ b/spec/TASK_4_SPEC.md
@@ -1,6 +1,6 @@
 # TASK_4 — Multi-user token-sync API + MongoDB persistence
 
-Branch: `task/4-token-sync-api` · Depends on: TASK_2, TASK_3 · Protocol: [AGENT.md](AGENT.md)
+Branch: `task/4-token-sync-api` · Depends on: TASK_2, TASK_3, TASK_10 · Protocol: [AGENT.md](AGENT.md)
 
 ## Goal
 
@@ -10,7 +10,9 @@ MongoDB. This API is the contract TASK_7 (shared client use case) consumes.
 
 ## Context
 
-- Server scaffold, Mongo client, env config, and `server/openapi.yaml` exist (TASK_3).
+- Server scaffold, Mongo client, and env config exist (TASK_3). OpenAPI generation from
+  the route definitions is in place (TASK_10): document these endpoints **in code**, not
+  by hand-editing `server/openapi.yaml`, and regenerate the snapshot.
 - `Session` is `@Serializable` with `name`, `key`, and `subscriber` (defaulted to 0 by
   TASK_2 — the wire shape documented there is authoritative) and importable into a
   `LastFMClient` (TASK_2).
@@ -70,12 +72,11 @@ MongoDB. This API is the contract TASK_7 (shared client use case) consumes.
 4. **Validation/errors:** malformed bodies → 400 with a JSON error shape (define it once
    in `openapi.yaml` and reuse); secrets never logged; Music-User-Token only ever logged
    as its hash.
-5. **OpenAPI:** `server/openapi.yaml` updated with the three paths, request/response
-   schemas (reuse the `Session` shape), the bearer scheme, and error responses. Task is
-   not done until the document matches the routes.
-   > Note: TASK_10 later regenerates this document from the route definitions. Keep the
-   > hand-written entries complete and accurate (schemas, examples, error responses) so
-   > that migration is a faithful snapshot.
+5. **OpenAPI (documented in code, per TASK_10):** annotate the three routes with their
+   OpenAPI documentation — request/response schemas (reuse the `Session` shape), the
+   bearer scheme, error responses, and examples — meeting TASK_10's completeness bar, and
+   regenerate `server/openapi.yaml` so the drift guard passes. Do **not** hand-edit the
+   YAML. Task is not done until the generated document matches the routes.
 6. **Tests:** Ktor `testApplication` route tests against an in-memory `UserStore` fake
    (interface + fake) for auth, happy paths, 400/401/404; plus `UserStore` integration
    tests against a real Mongo (Testcontainers, or the compose `mongodb` service with a

--- a/spec/TASK_4_SPEC.md
+++ b/spec/TASK_4_SPEC.md
@@ -73,6 +73,9 @@ MongoDB. This API is the contract TASK_7 (shared client use case) consumes.
 5. **OpenAPI:** `server/openapi.yaml` updated with the three paths, request/response
    schemas (reuse the `Session` shape), the bearer scheme, and error responses. Task is
    not done until the document matches the routes.
+   > Note: TASK_10 later regenerates this document from the route definitions. Keep the
+   > hand-written entries complete and accurate (schemas, examples, error responses) so
+   > that migration is a faithful snapshot.
 6. **Tests:** Ktor `testApplication` route tests against an in-memory `UserStore` fake
    (interface + fake) for auth, happy paths, 400/401/404; plus `UserStore` integration
    tests against a real Mongo (Testcontainers, or the compose `mongodb` service with a


### PR DESCRIPTION
## Summary

Adds the goal that **`server/openapi.yaml` is auto-generated from the existing on-code APIs** rather than hand-maintained, and captures it in the spec suite. Documentation-only change to `spec/` — no server code yet (that's TASK_10).

### What changed
- **New task [`spec/TASK_10_SPEC.md`](spec/TASK_10_SPEC.md)** — "Generate `openapi.yaml` from code". Routes carry their own OpenAPI documentation; `server/openapi.yaml` becomes a generated snapshot served at `GET /openapi.yaml`, with a **CI drift guard** and a **completeness bar** (every operation: summary/description, parameters incl. bearer + `Music-User-Token`, request body schema **with example**, **every** response status with schema + example incl. `/health`'s `mongo:false`, security scheme, `$ref`'d component schemas). Recommends the Ktor route-DSL generator `io.github.smiley4:ktor-openapi` (Ktor's own openapi/swagger plugins only *serve* a static file), left open to refinement in the task branch.
- **Ordering: TASK_10 runs _before_ TASK_4.** TASK_10 depends only on **TASK_3** and establishes the generation infrastructure + completeness bar from the `/health` surface; **TASK_4 gains a dependency on TASK_10** and documents its token endpoints **in code** from the start (no hand-edited YAML that a later task migrates). Task table, dependency graph, and waves updated (TASK_10 → wave 2; TASK_4 → wave 3).
- **Mandate reworked (`spec/AGENT.md`)** — the API-docs mandate targets code-generated docs as the end-state (code = single source of truth; checked-in yaml is a verified snapshot). Only TASK_3's initial document is hand-written (it predates TASK_10, which migrates it); from TASK_4 on, endpoints are documented on the route.
- **Orchestration (`spec/README.md`)** — decisions-record "API docs" row updated; TASK_10 added; graph/waves reflow; session-log entries.
- **`spec/TASK_4_SPEC.md`** — depends-on now `2, 3, 10`; its OpenAPI step rewritten from hand-editing YAML to documenting routes in code against TASK_10's completeness bar + regenerating the snapshot.

### Why a separate PR
Spec-direction change kept out of the open TASK_3 code PR (#84) to avoid scope creep, per the PR-per-change convention. It only edits the `spec/` folder; TASK_1–3 status rows are untouched so it merges cleanly alongside #84.

Atomic commits: (1) new TASK_10 spec, (2) mandate/orchestration wiring, (3) retarget TASK_10 before TASK_4.

---

## Also in this PR: CI fix — skip the build/test matrix on docs-only PRs

This spec-only PR was running the full `swiftlint`/`ktlint`/`android-lint`/`tests` matrix (~8 min) for no reason. Since this branch will be rebased anyway to resolve the README conflict, the fix rides along here so the rebased branch stops re-running the suite.

`.github/workflows/test.yml` now:
- adds a fast `changes` gate (`dorny/paths-filter`) that flags whether the PR touches anything outside `**/*.md`, `spec/**`, `docs/**`, `.github/**`, `LICENSE`;
- keeps the four job **names** (they're required checks on `main`, so they must always report — a *skipped* required job stays pending and blocks merge) but gates every step on that flag and drops each job to a cheap `ubuntu-latest` runner when there's no code. A docs-only PR gets four green checks in seconds instead of an Android+iOS build.
- `.github/**` is in the exclusion list so this very workflow change (and future workflow-only edits) also skips the heavy matrix.

It also brings the test command up to date (`:lastfmapi:jvmTest :server:test`) and the multi-module report artifact, matching TASK_3's CI change so the merged workflow is complete.
