### PR TITLE
TASK_10: generate server/openapi.yaml from code

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
           cache: gradle
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
           cache: gradle
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,7 @@ jobs:
         if: needs.changes.outputs.code == 'true'
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
           cache: gradle
       - name: Setup Gradle
         if: needs.changes.outputs.code == 'true'
@@ -125,7 +125,7 @@ jobs:
         if: needs.changes.outputs.code == 'true'
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
           cache: gradle
       - name: Setup Gradle
         if: needs.changes.outputs.code == 'true'
@@ -158,7 +158,7 @@ jobs:
         if: needs.changes.outputs.code == 'true'
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
           cache: gradle
       - name: Setup Gradle
         if: needs.changes.outputs.code == 'true'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,9 @@ kotlin = "2.4.0"
 kotlinxDatetime = "0.8.0-0.6.x-compat"
 kotlinxSerializationJson = "1.11.0"
 ktor = "3.5.1"
+ktorOpenApi = "5.7.0"
+# Schema/example generation backing ktor-openapi; version pinned to what ktor-openapi 5.7.0 uses.
+schemaKenerator = "2.7.2"
 coroutines = "1.11.0"
 kvault = "1.12.0"
 logback = "1.5.18"
@@ -63,6 +66,10 @@ ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negoti
 ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
 ktor-server-netty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }
 ktor-server-test-host = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
+ktor-openapi = { module = "io.github.smiley4:ktor-openapi", version.ref = "ktorOpenApi" }
+schemakenerator-core = { module = "io.github.smiley4:schema-kenerator-core", version.ref = "schemaKenerator" }
+schemakenerator-serialization = { module = "io.github.smiley4:schema-kenerator-serialization", version.ref = "schemaKenerator" }
+schemakenerator-swagger = { module = "io.github.smiley4:schema-kenerator-swagger", version.ref = "schemaKenerator" }
 kvault = { module = "com.liftric:kvault", version.ref = "kvault" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 mongodb-driver-kotlin-coroutine = { module = "org.mongodb:mongodb-driver-kotlin-coroutine", version.ref = "mongodb" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,8 @@ ktor = "3.5.1"
 ktorOpenApi = "5.7.0"
 # Schema/example generation backing ktor-openapi; version pinned to what ktor-openapi 5.7.0 uses.
 schemaKenerator = "2.7.2"
+# OpenAPI parser used only in tests to validate the generated document; matches ktor-openapi's.
+swaggerParser = "2.1.39"
 coroutines = "1.11.0"
 kvault = "1.12.0"
 logback = "1.5.18"
@@ -70,6 +72,7 @@ ktor-openapi = { module = "io.github.smiley4:ktor-openapi", version.ref = "ktorO
 schemakenerator-core = { module = "io.github.smiley4:schema-kenerator-core", version.ref = "schemaKenerator" }
 schemakenerator-serialization = { module = "io.github.smiley4:schema-kenerator-serialization", version.ref = "schemaKenerator" }
 schemakenerator-swagger = { module = "io.github.smiley4:schema-kenerator-swagger", version.ref = "schemaKenerator" }
+swagger-parser = { module = "io.swagger.parser.v3:swagger-parser", version.ref = "swaggerParser" }
 kvault = { module = "com.liftric:kvault", version.ref = "kvault" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 mongodb-driver-kotlin-coroutine = { module = "org.mongodb:mongodb-driver-kotlin-coroutine", version.ref = "mongodb" }

--- a/server/README.md
+++ b/server/README.md
@@ -43,8 +43,24 @@ slim **JRE 21** running as a non-root user.
 ## API document
 
 The single OpenAPI document for this server is [`server/openapi.yaml`](openapi.yaml),
-served at `GET /openapi.yaml`. Any task that adds or changes an endpoint must update
-it in the same change.
+served at `GET /openapi.yaml` (as `application/yaml`). **It is generated from the
+route definitions, not hand-edited** — the routes in
+[`Application.kt`](src/main/kotlin/dev/igorcferreira/musicstreamsync/server/Application.kt)
+carry their own OpenAPI documentation (summaries, schemas, examples, security) via the
+[`ktor-openapi`](https://github.com/SMILEY4/ktor-openapi-tools) plugin, and the code is
+the single source of truth.
+
+To document an endpoint, annotate its route. When the HTTP surface changes, regenerate
+the checked-in snapshot:
+
+```bash
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home
+./gradlew :server:generateOpenApi   # rewrites server/openapi.yaml from the code
+```
+
+`./gradlew :server:test` includes a drift guard that fails if `server/openapi.yaml` is
+out of sync with the routes, so CI catches a stale snapshot. Do not edit
+`server/openapi.yaml` by hand — it will be overwritten on the next regeneration.
 
 ## Health
 
@@ -55,7 +71,7 @@ unreachable — degradation is signaled in the payload rather than via 503.
 ## Building without Docker
 
 ```bash
-export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home
 ./gradlew :server:test          # unit tests (no MongoDB needed)
 ./gradlew :server:run           # needs SYNC_SHARED_SECRET and a reachable MongoDB
 ```

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -39,12 +39,14 @@ tasks.withType<Test>().configureEach {
 
 // Regenerate server/openapi.yaml from the code: runs only the snapshot test with the
 // write flag on. `./gradlew :server:generateOpenApi`.
+val testTask = tasks.named<Test>("test")
 tasks.register<Test>("generateOpenApi") {
     description = "Regenerates server/openapi.yaml from the documented routes."
     group = "documentation"
-    val testTask = tasks.named<Test>("test").get()
-    testClassesDirs = testTask.testClassesDirs
-    classpath = testTask.classpath
+    // Reuse the test source set's compiled classes and classpath without eagerly realizing
+    // the `test` task at configuration time.
+    testClassesDirs = files({ testTask.get().testClassesDirs })
+    classpath = files({ testTask.get().classpath })
     systemProperty("openapi.generate", "true")
     filter { includeTestsMatching("dev.igorcferreira.musicstreamsync.server.OpenApiDocumentTest") }
     outputs.upToDateWhen { false }
@@ -72,4 +74,5 @@ dependencies {
     testImplementation(libs.kotlin.test)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.ktor.server.test.host)
+    testImplementation(libs.swagger.parser)
 }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -25,10 +25,29 @@ application {
     mainClass.set("dev.igorcferreira.musicstreamsync.server.ApplicationKt")
 }
 
-// The canonical API document lives at server/openapi.yaml (spec/AGENT.md mandate);
-// package it into the jar so GET /openapi.yaml can serve it.
-tasks.processResources {
-    from(layout.projectDirectory.file("openapi.yaml"))
+// The canonical API document lives at server/openapi.yaml (spec/AGENT.md mandate).
+// It is generated from the route documentation (see the OpenApi plugin in Application.kt)
+// rather than hand-authored: the routes are the single source of truth and the served
+// GET /openapi.yaml renders the document at request time, so it is not packaged as a
+// resource. `openApiSnapshot` points both the drift guard (:server:test) and the
+// regeneration task at the checked-in snapshot.
+val openApiSnapshot = layout.projectDirectory.file("openapi.yaml")
+
+tasks.withType<Test>().configureEach {
+    systemProperty("openapi.file", openApiSnapshot.asFile.absolutePath)
+}
+
+// Regenerate server/openapi.yaml from the code: runs only the snapshot test with the
+// write flag on. `./gradlew :server:generateOpenApi`.
+tasks.register<Test>("generateOpenApi") {
+    description = "Regenerates server/openapi.yaml from the documented routes."
+    group = "documentation"
+    val testTask = tasks.named<Test>("test").get()
+    testClassesDirs = testTask.testClassesDirs
+    classpath = testTask.classpath
+    systemProperty("openapi.generate", "true")
+    filter { includeTestsMatching("dev.igorcferreira.musicstreamsync.server.OpenApiDocumentTest") }
+    outputs.upToDateWhen { false }
 }
 
 dependencies {
@@ -41,6 +60,13 @@ dependencies {
     implementation(libs.ktor.server.netty)
     implementation(libs.ktor.server.content.negotiation)
     implementation(libs.ktor.serialization.kotlinx.json)
+    implementation(libs.ktor.openapi)
+    // Kotlinx-serialization-backed schema/example generation for the OpenApi plugin; these
+    // schema-kenerator modules are implementation-scoped inside ktor-openapi, so they are
+    // declared here to make SchemaGenerator.kotlinx()/ExampleEncoder.kotlinx() resolvable.
+    implementation(libs.schemakenerator.core)
+    implementation(libs.schemakenerator.serialization)
+    implementation(libs.schemakenerator.swagger)
     implementation(libs.logback.classic)
     implementation(libs.mongodb.driver.kotlin.coroutine)
     testImplementation(libs.kotlin.test)

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -1,77 +1,105 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   title: MusicStreamSync Sync Server
-  description: |
+  description: |-
     HTTP API of the MusicStreamSync sync server: the native apps push per-user
     Apple Music and Last.fm credentials to it, and a scheduled loop syncs each
     user's Apple Music play history into Last.fm.
 
-    This is the **single** API document for the server; every task that adds or
-    changes an endpoint updates it in the same change (see spec/AGENT.md).
+    This document is generated from the server's route definitions; the code is
+    the single source of truth (see spec/AGENT.md).
   version: 0.1.0
+externalDocs:
+  description: MusicStreamSync sync-server spec suite
+  url: https://github.com/igorcferreira/MusicStreamSync/tree/main/spec
 servers:
-  - url: http://localhost:8080
-    description: Local development (docker compose up)
+- url: http://localhost:8080
+  description: Local development (docker compose up)
 tags:
-  - name: meta
-    description: Health and documentation endpoints
+- name: meta
+  description: Health and documentation endpoints.
 paths:
   /health:
     get:
-      operationId: getHealth
-      tags: [meta]
+      tags:
+      - meta
       summary: Service health
-      description: |
-        Liveness/readiness probe. Always returns 200 while the process is up;
-        `mongo` reflects a live ping to MongoDB and is `false` when the database
-        is unreachable (the endpoint deliberately does not switch to 503 — the
-        process itself is healthy and degradation is signaled in the payload).
-      security: []
+      description: |-
+        Liveness/readiness probe. Always returns 200 while the process is up; `mongo`
+        reflects a live ping to MongoDB and is `false` when the database is unreachable
+        (the endpoint deliberately does not switch to 503 — the process itself is
+        healthy and degradation is signaled in the payload).
+      operationId: getHealth
+      parameters: []
       responses:
         "200":
           description: Service is up.
+          headers: {}
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Health"
+                $ref: "#/components/schemas/HealthResponse"
               examples:
                 healthy:
-                  value: { "status": "ok", "mongo": true }
+                  summary: MongoDB reachable
+                  value:
+                    status: ok
+                    mongo: true
                 degraded:
                   summary: MongoDB unreachable
-                  value: { "status": "ok", "mongo": false }
+                  description: Process is healthy but the database ping failed.
+                  value:
+                    status: ok
+                    mongo: false
+      deprecated: false
   /openapi.yaml:
     get:
-      operationId: getOpenApiDocument
-      tags: [meta]
+      tags:
+      - meta
       summary: This document
-      security: []
+      description: "Returns this OpenAPI document, generated from the server's route\
+        \ definitions."
+      operationId: getOpenApiDocument
+      parameters: []
       responses:
         "200":
-          description: The OpenAPI document describing this server.
+          description: The OpenAPI 3.1 document describing this server.
+          headers: {}
           content:
             application/yaml:
               schema:
                 type: string
+              examples:
+                document:
+                  summary: Truncated document
+                  value: |-
+                    openapi: 3.1.0
+                    info:
+                      title: MusicStreamSync Sync Server
+                      version: 0.1.0
+                    paths:
+                      /health: { ... }
+                      /openapi.yaml: { ... }
+      deprecated: false
 components:
-  securitySchemes:
-    syncSharedSecret:
-      type: http
-      scheme: bearer
-      description: |
-        Shared-secret bearer token (the server's SYNC_SHARED_SECRET environment
-        variable). Required by every endpoint from the token API (TASK_4)
-        onwards; `/health` and `/openapi.yaml` are unauthenticated.
   schemas:
-    Health:
+    HealthResponse:
       type: object
-      required: [status, mongo]
       properties:
         status:
           type: string
-          enum: [ok]
         mongo:
           type: boolean
-          description: Result of a live MongoDB ping.
-security:
-  - syncSharedSecret: []
+      required:
+      - mongo
+      - status
+  examples: {}
+  securitySchemes:
+    syncSharedSecret:
+      type: http
+      description: |-
+        Shared-secret bearer token (the server's SYNC_SHARED_SECRET environment
+        variable). Required by every endpoint from the token API (TASK_4) onwards;
+        /health and /openapi.yaml are unauthenticated.
+      scheme: bearer
+webhooks: {}

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -71,15 +71,13 @@ paths:
                 type: string
               examples:
                 document:
-                  summary: Truncated document
+                  summary: Excerpt (full document elided)
                   value: |-
                     openapi: 3.1.0
                     info:
                       title: MusicStreamSync Sync Server
                       version: 0.1.0
-                    paths:
-                      /health: { ... }
-                      /openapi.yaml: { ... }
+                    # paths and components elided
       deprecated: false
 components:
   schemas:

--- a/server/src/main/kotlin/dev/igorcferreira/musicstreamsync/server/Application.kt
+++ b/server/src/main/kotlin/dev/igorcferreira/musicstreamsync/server/Application.kt
@@ -158,22 +158,23 @@ internal fun Application.module(pinger: DatabasePinger) {
                         mediaTypes(OPENAPI_CONTENT_TYPE)
                         description = "The generated OpenAPI document, as YAML."
                         example("document") {
-                            summary = "Truncated document"
+                            summary = "Excerpt (full document elided)"
                             value =
                                 """
                                 openapi: 3.1.0
                                 info:
                                   title: MusicStreamSync Sync Server
                                   version: 0.1.0
-                                paths:
-                                  /health: { ... }
-                                  /openapi.yaml: { ... }
+                                # paths and components elided
                                 """.trimIndent()
                         }
                     }
                 }
             }
         }) {
+            // getOpenApiSpec reads the document the plugin generated once at startup (a cached
+            // lookup, not a per-request rebuild). The drift-guard test exercises this path, so a
+            // generation failure is caught in CI rather than only surfacing as a runtime 500.
             call.respondText(
                 OpenApiPlugin.getOpenApiSpec(OpenApiPluginConfig.DEFAULT_SPEC_ID),
                 OPENAPI_CONTENT_TYPE,

--- a/server/src/main/kotlin/dev/igorcferreira/musicstreamsync/server/Application.kt
+++ b/server/src/main/kotlin/dev/igorcferreira/musicstreamsync/server/Application.kt
@@ -4,7 +4,18 @@ import com.mongodb.ConnectionString
 import com.mongodb.kotlin.client.coroutine.MongoClient
 import dev.igorcferreira.musicstreamsync.server.health.DatabasePinger
 import dev.igorcferreira.musicstreamsync.server.health.MongoDatabasePinger
+import io.github.smiley4.ktoropenapi.OpenApi
+import io.github.smiley4.ktoropenapi.OpenApiPlugin
+import io.github.smiley4.ktoropenapi.config.AuthScheme
+import io.github.smiley4.ktoropenapi.config.AuthType
+import io.github.smiley4.ktoropenapi.config.ExampleEncoder
+import io.github.smiley4.ktoropenapi.config.OpenApiPluginConfig
+import io.github.smiley4.ktoropenapi.config.OutputFormat
+import io.github.smiley4.ktoropenapi.config.SchemaGenerator
+import io.github.smiley4.ktoropenapi.get
+import io.github.smiley4.schemakenerator.swagger.data.RefType
 import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
@@ -13,9 +24,17 @@ import io.ktor.server.netty.Netty
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondText
-import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import kotlinx.serialization.Serializable
+
+/** Bearer security scheme name; the token API (TASK_4+) applies it to its token routes. */
+internal const val SYNC_SHARED_SECRET_SCHEME = "syncSharedSecret"
+
+/** Tag grouping the health and documentation endpoints. */
+private const val META_TAG = "meta"
+
+/** OpenAPI content type for the served document (kept distinct from `text/plain`). */
+private val OPENAPI_CONTENT_TYPE = ContentType("application", "yaml")
 
 fun main() {
     val config = ServerConfig.fromEnvironment()
@@ -32,21 +51,133 @@ fun main() {
 }
 
 internal fun Application.module(pinger: DatabasePinger) {
-    // Fail fast at startup when the API document was not packaged.
-    val openApiDocument =
-        checkNotNull(environment::class.java.classLoader.getResource("openapi.yaml")) {
-            "openapi.yaml is missing from the server resources"
-        }.readText()
-
     install(ContentNegotiation) {
         json()
     }
+    // Routes carry their own OpenAPI documentation; server/openapi.yaml is generated from
+    // them (the code is the single source of truth — see spec/AGENT.md and server/README.md).
+    install(OpenApi) {
+        info {
+            title = "MusicStreamSync Sync Server"
+            version = "0.1.0"
+            description =
+                """
+                HTTP API of the MusicStreamSync sync server: the native apps push per-user
+                Apple Music and Last.fm credentials to it, and a scheduled loop syncs each
+                user's Apple Music play history into Last.fm.
+
+                This document is generated from the server's route definitions; the code is
+                the single source of truth (see spec/AGENT.md).
+                """.trimIndent()
+        }
+        server {
+            url = "http://localhost:8080"
+            description = "Local development (docker compose up)"
+        }
+        externalDocs {
+            url = "https://github.com/igorcferreira/MusicStreamSync/tree/main/spec"
+            description = "MusicStreamSync sync-server spec suite"
+        }
+        tags {
+            tag(META_TAG) {
+                description = "Health and documentation endpoints."
+            }
+        }
+        // Generate schemas and encode examples with kotlinx-serialization so they match the
+        // @Serializable wire types the server actually uses. Body types (e.g. HealthResponse)
+        // are emitted as reusable component schemas with simple names and referenced via $ref.
+        schemas {
+            generator =
+                SchemaGenerator.kotlinx {
+                    referencePath = RefType.OPENAPI_SIMPLE
+                    title = null
+                }
+        }
+        examples {
+            encoder(ExampleEncoder.kotlinx())
+        }
+        // Model the bearer scheme now so TASK_4's `/api/*` routes can apply it. No default
+        // scheme is set, so the current (unauthenticated) routes carry no security requirement.
+        security {
+            securityScheme(SYNC_SHARED_SECRET_SCHEME) {
+                type = AuthType.HTTP
+                scheme = AuthScheme.BEARER
+                description =
+                    """
+                    Shared-secret bearer token (the server's SYNC_SHARED_SECRET environment
+                    variable). Required by every endpoint from the token API (TASK_4) onwards;
+                    /health and /openapi.yaml are unauthenticated.
+                    """.trimIndent()
+            }
+        }
+        outputFormat = OutputFormat.YAML
+    }
     routing {
-        get("/health") {
+        get("/health", {
+            operationId = "getHealth"
+            summary = "Service health"
+            description =
+                """
+                Liveness/readiness probe. Always returns 200 while the process is up; `mongo`
+                reflects a live ping to MongoDB and is `false` when the database is unreachable
+                (the endpoint deliberately does not switch to 503 — the process itself is
+                healthy and degradation is signaled in the payload).
+                """.trimIndent()
+            tags = listOf(META_TAG)
+            protected = false
+            response {
+                code(HttpStatusCode.OK) {
+                    description = "Service is up."
+                    body<HealthResponse> {
+                        description = "Process health, with the result of a live MongoDB ping."
+                        example("healthy") {
+                            summary = "MongoDB reachable"
+                            value = HealthResponse(status = "ok", mongo = true)
+                        }
+                        example("degraded") {
+                            summary = "MongoDB unreachable"
+                            description = "Process is healthy but the database ping failed."
+                            value = HealthResponse(status = "ok", mongo = false)
+                        }
+                    }
+                }
+            }
+        }) {
             call.respond(HealthResponse(status = "ok", mongo = pinger.ping()))
         }
-        get("/openapi.yaml") {
-            call.respondText(openApiDocument, ContentType("application", "yaml"))
+        get("/openapi.yaml", {
+            operationId = "getOpenApiDocument"
+            summary = "This document"
+            description = "Returns this OpenAPI document, generated from the server's route definitions."
+            tags = listOf(META_TAG)
+            protected = false
+            response {
+                code(HttpStatusCode.OK) {
+                    description = "The OpenAPI 3.1 document describing this server."
+                    body<String> {
+                        mediaTypes(OPENAPI_CONTENT_TYPE)
+                        description = "The generated OpenAPI document, as YAML."
+                        example("document") {
+                            summary = "Truncated document"
+                            value =
+                                """
+                                openapi: 3.1.0
+                                info:
+                                  title: MusicStreamSync Sync Server
+                                  version: 0.1.0
+                                paths:
+                                  /health: { ... }
+                                  /openapi.yaml: { ... }
+                                """.trimIndent()
+                        }
+                    }
+                }
+            }
+        }) {
+            call.respondText(
+                OpenApiPlugin.getOpenApiSpec(OpenApiPluginConfig.DEFAULT_SPEC_ID),
+                OPENAPI_CONTENT_TYPE,
+            )
         }
     }
 }

--- a/server/src/test/kotlin/dev/igorcferreira/musicstreamsync/server/OpenApiDocumentTest.kt
+++ b/server/src/test/kotlin/dev/igorcferreira/musicstreamsync/server/OpenApiDocumentTest.kt
@@ -4,6 +4,7 @@ import dev.igorcferreira.musicstreamsync.server.health.DatabasePinger
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
 import io.ktor.server.testing.testApplication
+import io.swagger.v3.parser.OpenAPIV3Parser
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -23,6 +24,9 @@ class OpenApiDocumentTest {
         System.getProperty("openapi.file")?.let(::File) ?: File("openapi.yaml")
     private val shouldRegenerate: Boolean = System.getProperty("openapi.generate") == "true"
 
+    // OpenApiPlugin holds the generated spec in process-global state keyed by spec id. These
+    // testApplication blocks all install the same module, so the shared DEFAULT_SPEC_ID registry
+    // is safe here; a future test installing a different route set in this JVM should be wary of it.
     private fun servedDocument(block: (String) -> Unit) =
         testApplication {
             application { module(DatabasePinger { true }) }
@@ -51,11 +55,10 @@ class OpenApiDocumentTest {
     fun generatedDocumentIsValidOpenApi3() =
         servedDocument { document ->
             assertTrue(document.startsWith("openapi: 3.1"), "Should be an OpenAPI 3.1 document")
-            assertContainsAll(
-                document,
-                "title: MusicStreamSync Sync Server",
-                "version: 0.1.0",
-            )
+            // Parse it with the OpenAPI parser so a structurally invalid document fails, not just
+            // one with the wrong first line.
+            val messages = OpenAPIV3Parser().readContents(document).messages.orEmpty()
+            assertTrue(messages.isEmpty(), "Document should be valid OpenAPI 3.x, parser reported: $messages")
         }
 
     @Test

--- a/server/src/test/kotlin/dev/igorcferreira/musicstreamsync/server/OpenApiDocumentTest.kt
+++ b/server/src/test/kotlin/dev/igorcferreira/musicstreamsync/server/OpenApiDocumentTest.kt
@@ -1,0 +1,100 @@
+package dev.igorcferreira.musicstreamsync.server
+
+import dev.igorcferreira.musicstreamsync.server.health.DatabasePinger
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.server.testing.testApplication
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Guards the checked-in [server/openapi.yaml] against the document generated from the
+ * documented routes (the code is the single source of truth — spec/AGENT.md).
+ *
+ * - Default run (`:server:test`): asserts the served document equals the checked-in snapshot
+ *   (the drift guard) and meets the completeness bar.
+ * - Regeneration run (`:server:generateOpenApi`, which sets `-Dopenapi.generate=true`): writes
+ *   the served document to the snapshot file instead of asserting equality.
+ */
+class OpenApiDocumentTest {
+    private val snapshot: File =
+        System.getProperty("openapi.file")?.let(::File) ?: File("openapi.yaml")
+    private val shouldRegenerate: Boolean = System.getProperty("openapi.generate") == "true"
+
+    private fun servedDocument(block: (String) -> Unit) =
+        testApplication {
+            application { module(DatabasePinger { true }) }
+            block(client.get("/openapi.yaml").bodyAsText())
+        }
+
+    @Test
+    fun servedDocumentMatchesCheckedInSnapshot() =
+        servedDocument { document ->
+            if (shouldRegenerate) {
+                snapshot.writeText(document)
+                return@servedDocument
+            }
+            assertTrue(
+                snapshot.isFile,
+                "Missing ${snapshot.path}; run ./gradlew :server:generateOpenApi",
+            )
+            assertEquals(
+                snapshot.readText(),
+                document,
+                "server/openapi.yaml is out of sync with the code; run ./gradlew :server:generateOpenApi",
+            )
+        }
+
+    @Test
+    fun generatedDocumentIsValidOpenApi3() =
+        servedDocument { document ->
+            assertTrue(document.startsWith("openapi: 3.1"), "Should be an OpenAPI 3.1 document")
+            assertContainsAll(
+                document,
+                "title: MusicStreamSync Sync Server",
+                "version: 0.1.0",
+            )
+        }
+
+    @Test
+    fun everyPathIsDocumentedWithResponsesExamplesAndSecurityScheme() =
+        servedDocument { document ->
+            // Both operations, with summaries and operationIds.
+            assertContainsAll(
+                document,
+                "/health:",
+                "operationId: getHealth",
+                "summary: Service health",
+                "/openapi.yaml:",
+                "operationId: getOpenApiDocument",
+            )
+            // Health responses reference the reusable schema (not inlined) and carry both examples.
+            assertContainsAll(
+                document,
+                "\$ref: \"#/components/schemas/HealthResponse\"",
+                "healthy:",
+                "degraded:",
+                "status: ok",
+                "mongo: false",
+            )
+            // The document response advertises the application/yaml media type.
+            assertTrue("application/yaml" in document, "openapi.yaml response should be application/yaml")
+            // The bearer scheme is modelled for the token API (TASK_4), even though no route uses it yet.
+            assertContainsAll(
+                document,
+                "securitySchemes:",
+                "syncSharedSecret:",
+                "scheme: bearer",
+                "type: http",
+            )
+        }
+
+    private fun assertContainsAll(
+        document: String,
+        vararg fragments: String,
+    ) = fragments.forEach { fragment ->
+        assertTrue(fragment in document, "Generated document should contain: $fragment")
+    }
+}

--- a/spec/AGENT.md
+++ b/spec/AGENT.md
@@ -87,10 +87,12 @@ All `:server` development, testing, and deployment happens with Docker support:
 
 ## Validation commands
 
-All Gradle commands use JDK 17:
+All Gradle commands use JDK 21 (the `:server` OpenAPI generation depends on
+`schema-kenerator`, whose published bytecode targets JDK 21; the Docker build/runtime
+and `:arkana` already use JDK 21):
 
 ```bash
-export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home
 ```
 
 | Check | Command |

--- a/spec/README.md
+++ b/spec/README.md
@@ -91,14 +91,14 @@ Status values: `pending` / `in_progress` / `in_review` (PR open) / `done` (PR me
 | --- | --- | --- | --- | --- | --- | --- |
 | 1 | `:shared` JVM target + actuals | — | done | `task/1-shared-jvm-target` | [#82](https://github.com/igorcferreira/MusicStreamSync/pull/82) | [TASK_1_SPEC.md](TASK_1_SPEC.md) |
 | 2 | lastfmapi session portability | — | done | `task/2-lastfm-session-portability` | [#83](https://github.com/igorcferreira/MusicStreamSync/pull/83) | [TASK_2_SPEC.md](TASK_2_SPEC.md) |
-| 3 | `:server` scaffold + Docker environment | — | in_review | `task/3-server-scaffold` | [#84](https://github.com/igorcferreira/MusicStreamSync/pull/84) | [TASK_3_SPEC.md](TASK_3_SPEC.md) |
+| 3 | `:server` scaffold + Docker environment | — | done | `task/3-server-scaffold` | [#84](https://github.com/igorcferreira/MusicStreamSync/pull/84) | [TASK_3_SPEC.md](TASK_3_SPEC.md) |
 | 4 | Multi-user token-sync API + persistence | 2, 3, 10 | pending | — | — | [TASK_4_SPEC.md](TASK_4_SPEC.md) |
 | 5 | Sync engine (diff + scrobble) | 1, 2 | pending | — | — | [TASK_5_SPEC.md](TASK_5_SPEC.md) |
 | 6 | Scheduler loop + wiring | 4, 5 | pending | — | — | [TASK_6_SPEC.md](TASK_6_SPEC.md) |
 | 7 | Shared push use case (`ServerSyncUseCase`) | 1, 2, 4 | pending | — | — | [TASK_7_SPEC.md](TASK_7_SPEC.md) |
 | 8 | Android app integration | 7 | pending | — | — | [TASK_8_SPEC.md](TASK_8_SPEC.md) |
 | 9 | iOS app integration | 7 | pending | — | — | [TASK_9_SPEC.md](TASK_9_SPEC.md) |
-| 10 | Generate `openapi.yaml` from code | 3 | pending | — | — | [TASK_10_SPEC.md](TASK_10_SPEC.md) |
+| 10 | Generate `openapi.yaml` from code | 3 | in_review | `task/10-openapi-generation` | [#86](https://github.com/igorcferreira/MusicStreamSync/pull/86) | [TASK_10_SPEC.md](TASK_10_SPEC.md) |
 
 ### Dependency graph / parallelism
 
@@ -136,3 +136,4 @@ documented in-code from the start.
 - 2026-07-10 — TASK_3 — `task/3-server-scaffold` — scaffolded the `:server` Ktor/JVM module (env `ServerConfig`, MongoDB coroutine client, DI `DatabasePinger`, `GET /health`), the single `server/openapi.yaml` served at `GET /openapi.yaml`, `:server:test` suites, and the Docker environment (multi-stage JDK21 build + JRE21 runtime, `docker-compose.yml`); `docker compose up` smoke passed. Extended CI (`test.yml`) to run the lastfmapi + server JVM tests. Rebased onto merged base; atomic commits; PR opened.
 - 2026-07-10 — spec — added the OpenAPI-generation goal: `server/openapi.yaml` will be generated from the code's route definitions (new TASK_10), reworked the API-docs mandate (AGENT.md) and the decisions record accordingly.
 - 2026-07-10 — spec — retargeted TASK_10 to run **before** TASK_4 (TASK_10 now needs only 3; TASK_4 gains a dependency on 10), so the token API is documented in-code from the start; updated the graph/waves and both task specs.
+- 2026-07-14 — TASK_10 — `task/10-openapi-generation` — migrated `server/openapi.yaml` to code-driven generation via `ktor-openapi` 5.7.0: `/health` and `/openapi.yaml` documented in-code, served doc generated as `application/yaml`, `:server:generateOpenApi` regenerates the snapshot, `OpenApiDocumentTest` drift-guards + validates it (swagger-parser) in `:server:test`. Modelled the `syncSharedSecret` bearer scheme in components with no global default (recorded the decision in TASK_10/TASK_4 specs). **Moved CI + local build to JDK 21** (schema-kenerator bytecode needs `SequencedCollection`; JDK 17 was not a hard constraint). Full matrix green (ktlint, generate/deterministic, `:server:test`, docker smoke, `:composeApp:assembleDebug`). Ran the pre-PR senior-Kotlin review and applied its findings; PR #86 opened. Also corrected TASK_3's stale `in_review` row to `done` (PR #84 merged).

--- a/spec/TASK_10_SPEC.md
+++ b/spec/TASK_10_SPEC.md
@@ -73,8 +73,14 @@ an endpoint" means annotating its route, and the Swagger document falls out auto
    - **every** response status the route can return (200 plus 400/401/404 as applicable),
      each with a schema and a realistic example (including the `/health` `mongo:false`
      degraded example);
-   - the `securityScheme` (bearer `syncSharedSecret`) modelled and applied to secured
-     routes, with `/health` and `/openapi.yaml` explicitly opted out (`security: []`);
+   - the `securityScheme` (bearer `syncSharedSecret`) modelled in `components` and applied
+     to secured routes, with `/health` and `/openapi.yaml` unauthenticated. **Implemented
+     decision:** the `ktor-openapi` generator models the scheme in `components` (emitted
+     whenever declared) but sets no document-level default security and emits **no**
+     `security` node for unprotected routes (`protected = false`) — semantically identical to
+     `security: []`. TASK_4 secures `/api/*` per-route via `protected = true` +
+     `securitySchemeNames("syncSharedSecret")`; if TASK_4 instead introduces a **global**
+     default scheme, it must then explicitly opt `/health` and `/openapi.yaml` back out.
    - reusable component schemas referenced via `$ref`, not inlined per operation.
    At TASK_3's surface this covers `/health` and `/openapi.yaml`; TASK_4 extends the same
    bar to the token payloads (`Session`, error) and `/api/*` security.

--- a/spec/TASK_10_SPEC.md
+++ b/spec/TASK_10_SPEC.md
@@ -97,7 +97,7 @@ an endpoint" means annotating its route, and the Swagger document falls out auto
 ## Validation
 
 ```bash
-export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home
 ./gradlew ktlintCheck
 ./gradlew :server:generateOpenApi   # (or the equivalent) — regenerates server/openapi.yaml
 ./gradlew :server:test              # includes the drift guard + completeness assertions

--- a/spec/TASK_1_SPEC.md
+++ b/spec/TASK_1_SPEC.md
@@ -109,7 +109,7 @@ entry point is `SyncEngine` in `:shared` jvmMain (TASK_5) plus the public
 ## Validation
 
 ```bash
-export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home
 ./gradlew ktlintCheck
 ./gradlew :shared:jvmTest
 ./gradlew :shared:testAndroidHostTest

--- a/spec/TASK_2_SPEC.md
+++ b/spec/TASK_2_SPEC.md
@@ -80,7 +80,7 @@ fully authenticated `LastFMClient` without ever seeing the user's password.
 ## Validation
 
 ```bash
-export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home
 ./gradlew ktlintCheck
 ./gradlew :lastfmapi:jvmTest          # includes the new round-trip + isolation tests
 ./gradlew :composeApp:assembleDebug

--- a/spec/TASK_3_SPEC.md
+++ b/spec/TASK_3_SPEC.md
@@ -22,7 +22,7 @@ tasks build on. **Docker is the primary dev/deploy environment** for this module
   `:lastfmapi`, `:arkana` (JVM-ready; provides `teamId`/`keyId`/`privateKey`/
   `lastFMAPIKey`/`lastFMAPISecret` — requires `arkana -l kotlin` before building, see
   root `CLAUDE.md`).
-- Build convention: JDK 17, ktlint (`alias(libs.plugins.ktlint)` like the other
+- Build convention: JDK 21, ktlint (`alias(libs.plugins.ktlint)` like the other
   modules).
 
 ## Requirements
@@ -73,7 +73,7 @@ tasks build on. **Docker is the primary dev/deploy environment** for this module
 ## Validation
 
 ```bash
-export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home
 ./gradlew ktlintCheck
 ./gradlew :server:test
 ./gradlew :composeApp:assembleDebug        # repo stays green

--- a/spec/TASK_4_SPEC.md
+++ b/spec/TASK_4_SPEC.md
@@ -77,6 +77,12 @@ MongoDB. This API is the contract TASK_7 (shared client use case) consumes.
    bearer scheme, error responses, and examples — meeting TASK_10's completeness bar, and
    regenerate `server/openapi.yaml` so the drift guard passes. Do **not** hand-edit the
    YAML. Task is not done until the generated document matches the routes.
+   - **Security wiring (from TASK_10):** the `syncSharedSecret` bearer scheme is already
+     modelled in `components` and TASK_10 sets **no** global default security. Secure the
+     `/api/*` routes per-route with `protected = true` +
+     `securitySchemeNames("syncSharedSecret")`. If you instead add a document-level default
+     scheme, you must explicitly opt `/health` and `/openapi.yaml` back out — they are
+     unauthenticated and must stay so.
 6. **Tests:** Ktor `testApplication` route tests against an in-memory `UserStore` fake
    (interface + fake) for auth, happy paths, 400/401/404; plus `UserStore` integration
    tests against a real Mongo (Testcontainers, or the compose `mongodb` service with a

--- a/spec/TASK_4_SPEC.md
+++ b/spec/TASK_4_SPEC.md
@@ -91,7 +91,7 @@ MongoDB. This API is the contract TASK_7 (shared client use case) consumes.
 ## Validation
 
 ```bash
-export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home
 ./gradlew ktlintCheck
 ./gradlew :server:test
 docker compose build

--- a/spec/TASK_5_SPEC.md
+++ b/spec/TASK_5_SPEC.md
@@ -104,7 +104,7 @@ C → C; A again → A; nothing new → nothing).
 ## Validation
 
 ```bash
-export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home
 ./gradlew ktlintCheck
 ./gradlew :shared:jvmTest
 ./gradlew :composeApp:assembleDebug

--- a/spec/TASK_6_SPEC.md
+++ b/spec/TASK_6_SPEC.md
@@ -73,7 +73,7 @@ for each, with per-user failure isolation and operational visibility.
 ## Validation
 
 ```bash
-export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home
 ./gradlew ktlintCheck
 ./gradlew :server:test
 docker compose build

--- a/spec/TASK_7_SPEC.md
+++ b/spec/TASK_7_SPEC.md
@@ -67,7 +67,7 @@ This is the only piece of client networking against the server API.
 ## Validation
 
 ```bash
-export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home
 ./gradlew ktlintCheck
 ./gradlew :shared:testAndroidHostTest :shared:jvmTest
 ./gradlew iosSimulatorArm64Test

--- a/spec/TASK_8_SPEC.md
+++ b/spec/TASK_8_SPEC.md
@@ -45,7 +45,7 @@ settings surface in `composeApp` wired to `ServerSyncUseCase`.
 ## Validation
 
 ```bash
-export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home
 ./gradlew ktlintCheck
 ./gradlew :composeApp:assembleDebug
 ./gradlew :shared:testAndroidHostTest

--- a/spec/TASK_9_SPEC.md
+++ b/spec/TASK_9_SPEC.md
@@ -45,7 +45,7 @@ configures the sync server and pushes the user's tokens via the shared
 ## Validation
 
 ```bash
-export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home
 ./gradlew ktlintCheck
 ./gradlew :shared:assembleMusicStreamXCFramework
 ./gradlew iosSimulatorArm64Test


### PR DESCRIPTION
Implements **TASK_10** ([spec/TASK_10_SPEC.md](spec/TASK_10_SPEC.md)): make the code the single source of truth for the server's OpenAPI document. Targets `feature/kotlin-server/base`.

## What changed
- **Routes documented in code.** `/health` and `/openapi.yaml` now carry their own OpenAPI documentation (summary/description/tags, response schema from the `@Serializable` `HealthResponse`, both `healthy`/`degraded` examples incl. the `mongo:false` degraded case) via the [`ktor-openapi`](https://github.com/SMILEY4/ktor-openapi-tools) 5.7.0 route DSL.
- **`server/openapi.yaml` is generated, not authored.** The served `GET /openapi.yaml` renders the generated document (`OpenApiPlugin.getOpenApiSpec`) as `application/yaml`; the hand-written resource + `processResources` packaging are gone.
- **Regeneration + drift guard.** `./gradlew :server:generateOpenApi` rewrites the snapshot; `OpenApiDocumentTest` (in `:server:test`, so CI) compares the served document to the checked-in file and asserts validity (via swagger-parser), completeness, and the security scheme. Same generation path feeds both, so served == checked-in by construction.
- **Security scheme modelled** (`syncSharedSecret`, bearer) in `components` for TASK_4; no global default is set (see decision below).
- Kotlinx-serialization-backed schema/example generation (`SchemaGenerator.kotlinx`, `ExampleEncoder.kotlinx`) with simple component names.
- `server/README.md` updated: the file is generated, how to regenerate, do-not-edit-by-hand.

## JDK 17 → 21 (authorised mid-task)
`schema-kenerator` (via ktor-openapi) ships bytecode calling `java.util.List.removeFirst()` (JDK 21 `SequencedCollection`), so `:server` schema generation throws `NoSuchMethodError` on JDK 17. JDK 17 was not a hard constraint (Docker build/runtime and `:arkana` already use JDK 21), so CI (`build.yml`, `test.yml`) and the spec/README validation commands were moved to JDK 21. Module `jvmTarget`s stay at 17 (portable bytecode runs on the JDK 21 JVM).

## Decision: security modelling
The generator models `syncSharedSecret` in `components` but sets no document-level default and emits no `security` node for unprotected routes (`protected = false`) — semantically identical to `security: []`. TASK_10 spec req 4 and TASK_4's spec were updated to record this; TASK_4 secures `/api/*` per-route (or must re-opt the meta routes out if it adds a global default).

## Validation (JDK 21) — all green
- `./gradlew ktlintCheck`
- `./gradlew :server:generateOpenApi` (deterministic — regenerated twice, identical)
- `./gradlew :server:test` (drift guard + swagger-parser validity + completeness)
- `docker compose build` + smoke: `/health` → `{"status":"ok","mongo":true}`, `/openapi.yaml` → `application/yaml`, served == checked-in
- `./gradlew :composeApp:assembleDebug`

A senior-Kotlin pre-PR review (per the README mandate) was run; its findings (real OpenAPI validation, lazy `generateOpenApi`, the invalid-YAML example, and documenting the `security` decision for TASK_4) are applied in the last two commits.